### PR TITLE
remove unused react-icons dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage"
   },
-  "dependencies": {
-    "react-icons": "^5.5.0"
-  },
+
   "devDependencies": {
     "@types/bun": "^1.2.23",
     "typescript": "^5.9.3"


### PR DESCRIPTION
fix #55 

The project is built entirely with vanilla JavaScript (ES Modules) and HTML5 Canvas, and there is no React usage anywhere in the codebase. The dependency was unused and likely introduced by mistake.

Why this change is needed

react-icons is a React-only runtime dependency

No React, JSX, or React tooling exists in the project

The dependency added unnecessary weight to node_modules

Keeping unused dependencies increases maintenance cost and causes confusion for contributors