### PR TITLE
fix: prevent playerSystem endSleep from running twice

### DIFF
--- a/public/scripts/thePlayer/playerSystem.js
+++ b/public/scripts/thePlayer/playerSystem.js
@@ -348,6 +348,8 @@ export class PlayerSystem {
      * @returns {void}
      */
     startSleep() {
+        if (this._sleepActive) return;
+        
         // reset guards for a new sleep cycle
         this._sleepActive = true;
         this._sleepEnding = false;


### PR DESCRIPTION
fix #60 

The sleep flow currently has two independent end triggers:
PlayerSystem starts a setInterval in startSleep() that restores energy and calls endSleep() once energy reaches max.
A sleepEnded document event is dispatched externally (e.g., WeatherSystem fade-in completion), and PlayerSystem also listens to this event and calls endSleep().
Because both triggers can happen close together (or even the same frame), endSleep() may execute twice, which can:
Dispatch sleepCompleted redundantly, causing duplicated downstream effects.
Lead to inconsistent state transitions (double cleanups, duplicated notifications in systems listening to sleepCompleted, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved player sleep flow to prevent double-ending and re-entry during sleep, ensuring energy is reliably restored to full when waking.
  * Better cleanup after sleep cycles so sleeping state and timers are cleared correctly, reducing cases of stuck or inconsistent player sleep status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->