### PR TITLE
feat(#170): wire orphan items, add item info panel, fix construction

### DIFF
--- a/public/scripts/buildSystem.js
+++ b/public/scripts/buildSystem.js
@@ -11,7 +11,7 @@ import { inventorySystem } from "./thePlayer/inventorySystem.js";
 import { camera, CAMERA_ZOOM } from "./thePlayer/cameraSystem.js";
 import { TILE_SIZE } from "./worldConstants.js";
 import { perfLog } from "./optimizationConstants.js";
-import { wellSystem } from "./wellSystem.js";
+import { wellSystem as importedWellSystem } from "./wellSystem.js";
 import { t } from './i18n/i18n.js';
 import { MOUSE_UPDATE_INTERVAL_MS, DEBUG_UPDATE_INTERVAL_MS, VISUAL } from './constants.js';
 import { getObject, getSystem } from "./gameState.js";
@@ -600,19 +600,20 @@ export const BuildSystem = {
         }
 
         if (constructionType === 'well') {
-            const wellSystem = getSystem('well');
-            if (!wellSystem && !(window.theWorld && typeof window.theWorld.placeWell === 'function')) {
-                // Trigger lazy load so next click works.
-                import('./wellSystem.js').catch(err => logger.warn('wellSystem lazy load failed', err));
+            // wellSystem is statically imported at the top of this file, so it's
+            // always available. Prefer the registry copy (gameState) but fall
+            // back to the static import if registration hasn't happened yet.
+            const availableWellSystem = getSystem('well') ?? importedWellSystem;
+            if (!availableWellSystem && !(window.theWorld && typeof window.theWorld.placeWell === 'function')) {
                 this.showDebugMessage(t('build.wellLoading'), 1500);
                 return;
             }
-            if ((wellSystem && typeof wellSystem.placeWell === 'function') || (window.theWorld && typeof window.theWorld.placeWell === 'function')) {
-                
+            if ((availableWellSystem && typeof availableWellSystem.placeWell === 'function') || (window.theWorld && typeof window.theWorld.placeWell === 'function')) {
+
                 const wellId = `well_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-                
+
                 const wellBuildingData = {
-                    id: wellId, 
+                    id: wellId,
                     itemId: this.selectedItem.id,
                     name: this.selectedItem.name,
                     assetId: this.selectedItem.assetId || 'well',
@@ -628,8 +629,8 @@ export const BuildSystem = {
                     let wellObject = null;
                     if (window.theWorld && typeof window.theWorld.placeWell === 'function') {
                         wellObject = window.theWorld.placeWell(pos.x, pos.y, wellBuildingData);
-                    } else if (wellSystem) {
-                        wellObject = wellSystem.placeWell(wellId, pos.x, pos.y);
+                    } else if (availableWellSystem) {
+                        wellObject = availableWellSystem.placeWell(wellId, pos.x, pos.y);
                     }
 
                     if (wellObject) {

--- a/public/scripts/buildSystem.js
+++ b/public/scripts/buildSystem.js
@@ -559,7 +559,13 @@ export const BuildSystem = {
 
         if (constructionType === 'chest') {
             const chestSystem = getSystem('chest');
-            if (chestSystem && typeof chestSystem.addChest === 'function') {
+            if (!chestSystem) {
+                // Trigger lazy load so the next click works.
+                import('./chestSystem.js').catch(err => logger.warn('chestSystem lazy load failed', err));
+                this.showDebugMessage(t('build.chestLoading'), 1500);
+                return;
+            }
+            if (typeof chestSystem.addChest === 'function') {
                 const newChestId = `chest_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
                 
                 const buildingData = {
@@ -595,7 +601,13 @@ export const BuildSystem = {
 
         if (constructionType === 'well') {
             const wellSystem = getSystem('well');
-            if ((wellSystem && typeof wellSystem.placeWell === 'function') || (window.theWorld && typeof window.theWorld.placeWell === 'function')) { 
+            if (!wellSystem && !(window.theWorld && typeof window.theWorld.placeWell === 'function')) {
+                // Trigger lazy load so next click works.
+                import('./wellSystem.js').catch(err => logger.warn('wellSystem lazy load failed', err));
+                this.showDebugMessage(t('build.wellLoading'), 1500);
+                return;
+            }
+            if ((wellSystem && typeof wellSystem.placeWell === 'function') || (window.theWorld && typeof window.theWorld.placeWell === 'function')) {
                 
                 const wellId = `well_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
                 

--- a/public/scripts/constants.js
+++ b/public/scripts/constants.js
@@ -69,7 +69,11 @@ export const GAME_BALANCE = {
     DEFAULT_HP: 1,
     AXE_DAMAGE: 2,
     PICKAXE_DAMAGE: 2,
-    MACHETE_DAMAGE: 1
+    MACHETE_DAMAGE: 1,
+    // Issue #170: Shears as an alternative to the machete for pruning
+    // thickets. Same damage (one-shot on thicket HP 1) — both work, the
+    // player picks. Adjust here if balance ever needs to differentiate.
+    SHEARS_DAMAGE: 1
   },
 
   NEEDS: {

--- a/public/scripts/i18n/en.js
+++ b/public/scripts/i18n/en.js
@@ -209,7 +209,7 @@ export default {
         tool: 'Tool',
         seed: 'Seed',
         food: 'Food',
-        animal_food: 'Animal food',
+        animal_food: 'Animal Feed',
         medicine: 'Medicine',
         animal: 'Animal',
         resource: 'Resource',

--- a/public/scripts/i18n/en.js
+++ b/public/scripts/i18n/en.js
@@ -146,6 +146,14 @@ export default {
     animals: 'Animals',
     resource: 'Resource',
     material: 'Materials',
+    // Issue #170: singular aliases that match `item.type` values directly,
+    // used by callers that look up `categories.${item.type}` (craftingSystem,
+    // merchant). Without these the console warns about missing translations.
+    tool: 'Tool',
+    seed: 'Seed',
+    crop: 'Crop',
+    medicine: 'Medicine',
+    animal: 'Animal',
   },
 
   // Inventory System
@@ -174,6 +182,46 @@ export default {
     },
     toolWheel: {
       empty: 'No tools in inventory'
+    },
+    details: {
+      sectionTitle: 'Technical info',
+      type: 'Type',
+      toolType: 'Tool',
+      restores: 'Restores',
+      hunger: 'Hunger',
+      thirst: 'Thirst',
+      energy: 'Energy',
+      acceptedBy: 'Accepted by',
+      foodValue: 'Food value',
+      treats: 'Treats',
+      cureMode: 'Cure',
+      instant: 'Instant',
+      gradual: '{n} days',
+      dosesPerDay: 'Doses per day',
+      palatability: 'Palatability',
+      palatable: 'Palatable',
+      neutral: 'Neutral',
+      bitter: 'Bitter',
+      size: 'Size',
+      placeable: 'Placeable',
+      experimental: 'Under development',
+      types: {
+        tool: 'Tool',
+        seed: 'Seed',
+        food: 'Food',
+        animal_food: 'Animal food',
+        medicine: 'Medicine',
+        animal: 'Animal',
+        resource: 'Resource',
+        crop: 'Crop',
+        construction: 'Construction'
+      },
+      diseases: {
+        parasitosis: 'Parasitosis',
+        respiratory: 'Respiratory',
+        digestive: 'Digestive',
+        fever: 'Fever'
+      }
     },
     confirmDiscard: 'Discard {name}?',
     selectItem: 'Select an item'
@@ -538,6 +586,20 @@ export default {
     help: {
       label: 'Help',
       desc: 'Open/close shortcuts'
+    },
+    // Issue #170: human-readable tool type names (toolType field on items).
+    // Shown on the inventory details panel as "Type: Axe" etc.
+    toolTypes: {
+      shears: 'Shears',
+      hoe: 'Hoe',
+      hammer: 'Hammer',
+      scythe: 'Scythe',
+      watering_can: 'Watering Can',
+      pickaxe: 'Pickaxe',
+      axe: 'Axe',
+      rake: 'Rake',
+      bucket: 'Bucket',
+      machete: 'Machete'
     }
   },
 

--- a/public/scripts/i18n/es.js
+++ b/public/scripts/i18n/es.js
@@ -209,7 +209,7 @@ export default {
         tool: 'Herramienta',
         seed: 'Semilla',
         food: 'Comida',
-        animal_food: 'Comida de animal',
+        animal_food: 'Alimento Animal',
         medicine: 'Medicina',
         animal: 'Animal',
         resource: 'Recurso',

--- a/public/scripts/i18n/es.js
+++ b/public/scripts/i18n/es.js
@@ -146,6 +146,14 @@ export default {
     animals: 'Animales',
     resource: 'Recurso',
     material: 'Materiales',
+    // Issue #170: singular aliases that match `item.type` values directly,
+    // used by callers that look up `categories.${item.type}` (craftingSystem,
+    // merchant). Without these the console warns about missing translations.
+    tool: 'Herramienta',
+    seed: 'Semilla',
+    crop: 'Cosecha',
+    medicine: 'Medicina',
+    animal: 'Animal',
   },
 
   // Inventory System
@@ -174,6 +182,46 @@ export default {
     },
     toolWheel: {
       empty: 'No hay herramientas en el inventario'
+    },
+    details: {
+      sectionTitle: 'Información técnica',
+      type: 'Tipo',
+      toolType: 'Herramienta',
+      restores: 'Restaura',
+      hunger: 'Hambre',
+      thirst: 'Sed',
+      energy: 'Energía',
+      acceptedBy: 'Aceptado por',
+      foodValue: 'Valor nutritivo',
+      treats: 'Trata',
+      cureMode: 'Cura',
+      instant: 'Inmediata',
+      gradual: '{n} días',
+      dosesPerDay: 'Dosis por día',
+      palatability: 'Sabor',
+      palatable: 'Agradable',
+      neutral: 'Neutro',
+      bitter: 'Amargo',
+      size: 'Tamaño',
+      placeable: 'Construible',
+      experimental: 'En desarrollo',
+      types: {
+        tool: 'Herramienta',
+        seed: 'Semilla',
+        food: 'Comida',
+        animal_food: 'Comida de animal',
+        medicine: 'Medicina',
+        animal: 'Animal',
+        resource: 'Recurso',
+        crop: 'Cosecha',
+        construction: 'Construcción'
+      },
+      diseases: {
+        parasitosis: 'Parasitosis',
+        respiratory: 'Respiratoria',
+        digestive: 'Digestiva',
+        fever: 'Fiebre'
+      }
     },
     confirmDiscard: '¿Descartar {name}?',
     selectItem: 'Selecciona un artículo'
@@ -538,6 +586,20 @@ export default {
     help: {
       label: 'Ayuda',
       desc: 'Abrir/cerrar atajos'
+    },
+    // Issue #170: human-readable tool type names (toolType field on items).
+    // Shown on the inventory details panel as "Type: Axe" etc.
+    toolTypes: {
+      shears: 'Tijeras',
+      hoe: 'Azada',
+      hammer: 'Martillo',
+      scythe: 'Guadaña',
+      watering_can: 'Regadera',
+      pickaxe: 'Pico',
+      axe: 'Hacha',
+      rake: 'Rastrillo',
+      bucket: 'Cubo',
+      machete: 'Machete'
     }
   },
 

--- a/public/scripts/i18n/pt-BR.js
+++ b/public/scripts/i18n/pt-BR.js
@@ -209,7 +209,7 @@ export default {
         tool: 'Ferramenta',
         seed: 'Semente',
         food: 'Comida',
-        animal_food: 'Comida de animal',
+        animal_food: 'Ração',
         medicine: 'Remédio',
         animal: 'Animal',
         resource: 'Recurso',

--- a/public/scripts/i18n/pt-BR.js
+++ b/public/scripts/i18n/pt-BR.js
@@ -146,6 +146,14 @@ export default {
     animals: 'Animais',
     resource: 'Recurso',
     material: 'Materiais',
+    // Issue #170: singular aliases that match `item.type` values directly,
+    // used by callers that look up `categories.${item.type}` (craftingSystem,
+    // merchant). Without these the console warns about missing translations.
+    tool: 'Ferramenta',
+    seed: 'Semente',
+    crop: 'Colheita',
+    medicine: 'Remédio',
+    animal: 'Animal',
   },
 
   // Inventory System
@@ -174,6 +182,46 @@ export default {
     },
     toolWheel: {
       empty: 'Nenhuma ferramenta no inventário'
+    },
+    details: {
+      sectionTitle: 'Informações técnicas',
+      type: 'Tipo',
+      toolType: 'Ferramenta',
+      restores: 'Restaura',
+      hunger: 'Fome',
+      thirst: 'Sede',
+      energy: 'Energia',
+      acceptedBy: 'Aceito por',
+      foodValue: 'Valor nutritivo',
+      treats: 'Trata',
+      cureMode: 'Cura',
+      instant: 'Imediata',
+      gradual: '{n} dias',
+      dosesPerDay: 'Doses por dia',
+      palatability: 'Sabor',
+      palatable: 'Agradável',
+      neutral: 'Neutro',
+      bitter: 'Amargo',
+      size: 'Tamanho',
+      placeable: 'Construível',
+      experimental: 'Em desenvolvimento',
+      types: {
+        tool: 'Ferramenta',
+        seed: 'Semente',
+        food: 'Comida',
+        animal_food: 'Comida de animal',
+        medicine: 'Remédio',
+        animal: 'Animal',
+        resource: 'Recurso',
+        crop: 'Colheita',
+        construction: 'Construção'
+      },
+      diseases: {
+        parasitosis: 'Verminose',
+        respiratory: 'Respiratória',
+        digestive: 'Digestiva',
+        fever: 'Febre'
+      }
     },
     confirmDiscard: 'Descartar {name}?',
     selectItem: 'Selecione um item'
@@ -537,6 +585,20 @@ export default {
     help: {
       label: 'Ajuda',
       desc: 'Abrir/fechar atalhos'
+    },
+    // Issue #170: human-readable tool type names (toolType field on items).
+    // Shown on the inventory details panel as "Type: Axe" etc.
+    toolTypes: {
+      shears: 'Tesoura',
+      hoe: 'Enxada',
+      hammer: 'Martelo',
+      scythe: 'Foice',
+      watering_can: 'Regador',
+      pickaxe: 'Picareta',
+      axe: 'Machado',
+      rake: 'Rastelo',
+      bucket: 'Balde',
+      machete: 'Machete'
     }
   },
 

--- a/public/scripts/item.js
+++ b/public/scripts/item.js
@@ -311,7 +311,12 @@ export const items = [
     price: 40,
     description: "Usada para alimentar ovelhas",
     type: "animal_food",
-    targetAnimals: ["Lamb", "Sheep"]
+    // Issue #170: was missing foodValue + nutrition (compare with id 7
+    // which had the full structure). Without these, feeding sheep had
+    // no effect on the animal.
+    foodValue: 12,
+    targetAnimals: ["Lamb", "Sheep"],
+    nutrition: { energy: 5, happiness: 3 }
   },
   {
     id: 29,
@@ -634,24 +639,28 @@ export const items = [
     type: "animal_food",
     targetAnimals: ["Chick", "Chicken", "Rooster", "Turkey"]
   },
-  {
-    id: 101,
-    name: "ração para felinos",
-    icon: "assets/icons/catFeedIcon.png",
-    price: 30,
-    description: "Ração especializada para gatos domésticos",
-    type: "animal_food",
-    targetAnimals: []  // nenhuma espécie atual do farm — pra gato futuro
-  },
-  {
-    id: 102,
-    name: "ração para cachorros",
-    icon: "assets/icons/dogFeedIcon.png",
-    price: 30,
-    description: "Ração especializada para cães domésticos",
-    type: "animal_food",
-    targetAnimals: []  // nenhuma espécie atual do farm — pra cachorro futuro
-  },
+  /* Issue #170: Cat feed (101) and dog feed (102) are reserved.
+     No "Cat" or "Dog" species exist on the farm yet — when they arrive,
+     uncomment below + populate `targetAnimals`. Kept as a roadmap
+     breadcrumb instead of deleting outright. */
+  // {
+  //   id: 101,
+  //   name: "ração para felinos",
+  //   icon: "assets/icons/catFeedIcon.png",
+  //   price: 30,
+  //   description: "Ração especializada para gatos domésticos",
+  //   type: "animal_food",
+  //   targetAnimals: ["Cat"]
+  // },
+  // {
+  //   id: 102,
+  //   name: "ração para cachorros",
+  //   icon: "assets/icons/dogFeedIcon.png",
+  //   price: 30,
+  //   description: "Ração especializada para cães domésticos",
+  //   type: "animal_food",
+  //   targetAnimals: ["Dog"]
+  // },
   // ==================================================================================
 
   // ==================================================================================
@@ -672,7 +681,10 @@ export const items = [
     icon: "🏠",
     price: 25,
     description: "Para telhados das construções",
-    type: "resource"
+    type: "resource",
+    // Issue #170: no recipe to produce nor consume. Marked experimental —
+    // reserved for a future custom house-roof feature.
+    experimental: true
   },
   {
     id: 34,
@@ -696,7 +708,10 @@ export const items = [
     icon: "assets/icons/glassIcon.png",
     price: 35,
     description: "Para janelas e estufas",
-    type: "resource"
+    type: "resource",
+    // Issue #170: no recipe to produce nor consume. Reserved for a future
+    // greenhouse feature (planting #2) or custom house windows.
+    experimental: true
   },
   {
     id: 37,
@@ -712,7 +727,10 @@ export const items = [
     icon: "assets/icons/temperedSteelIcon.png",
     price: 90,
     description: "material resistente para construção",
-    type: "resource"
+    type: "resource",
+    // Issue #170: no recipe to produce nor consume. Reserved for future
+    // tier-2 tools or advanced structures.
+    experimental: true
   },
   {
     id: 48,
@@ -720,7 +738,10 @@ export const items = [
     icon: "assets/icons/threadIcon.png",
     price: 8,
     description: "Para costurar e craftar",
-    type: "resource"
+    type: "resource",
+    // Issue #170: no recipe to produce nor consume. Reserved for future
+    // clothing or refined-fabric recipes.
+    experimental: true
   },
   {
     id: 49,
@@ -736,7 +757,10 @@ export const items = [
     icon: "assets/icons/paintBucketIcon.png",
     price: 25,
     description: "Para colorir construções",
-    type: "resource"
+    type: "resource",
+    // Issue #170: no recipe to produce nor consume. Reserved for a future
+    // building color-customization feature.
+    experimental: true
   },
   {
     id: 51,
@@ -744,7 +768,9 @@ export const items = [
     icon: "assets/icons/glueIcon.png",
     price: 12,
     description: "Para colar materiais",
-    type: "resource"
+    type: "resource",
+    // Issue #170: no recipe to produce nor consume. Reserved.
+    experimental: true
   },
   {
     id: 52,
@@ -752,7 +778,10 @@ export const items = [
     icon: "assets/icons/toolboxIcon.png",
     price: 55,
     description: "Conserta ferramentas danificadas",
-    type: "resource"
+    type: "resource",
+    // Issue #170: blocked by the tool-durability feature which doesn't
+    // exist yet. Marked experimental until the spec lands.
+    experimental: true
   },
   {
     id: 58,
@@ -784,7 +813,10 @@ export const items = [
     icon: "▭",
     price: 35,
     description: "Metal laminado para estruturas",
-    type: "resource"
+    type: "resource",
+    // Issue #170: no recipe to produce nor consume. Reserved for future
+    // industrial-tier structures.
+    experimental: true
   },
   {
     id: 75,
@@ -792,7 +824,13 @@ export const items = [
     icon: "assets/icons/screwIcon.png",
     price: 3,
     description: "Para fixações mais resistentes",
-    type: "resource"
+    type: "resource",
+    // Issue #170: consolidated with Nail (34). Screw was pulled from the
+    // water-trough recipe to avoid confusing two functionally identical
+    // fasteners. Kept experimental — if a future feature adds a durability
+    // tier or industrial structures, Screw becomes the premium fastener.
+    // Dormant for now.
+    experimental: true
   },
   {
     id: 76,

--- a/public/scripts/itemSystem.js
+++ b/public/scripts/itemSystem.js
@@ -230,6 +230,11 @@ export class ItemSystem {
                 } else if (targetType === 'thicket' && equippedTool.toolType === 'machete') {
                     damage = equippedTool.damage || GAME_BALANCE.DAMAGE.MACHETE_DAMAGE;
                     isCorrectTool = true;
+                } else if (targetType === 'thicket' && equippedTool.toolType === 'shears') {
+                    // Issue #170: Shears as an alternative for pruning thickets.
+                    // Same damage as machete; player picks which one to carry.
+                    damage = equippedTool.damage || GAME_BALANCE.DAMAGE.SHEARS_DAMAGE;
+                    isCorrectTool = true;
                 }
             }
 
@@ -258,7 +263,10 @@ export class ItemSystem {
         switch (type) {
             case 'tree': return 'machado';
             case 'rock': return 'picareta';
-            case 'thicket': return 'facão';
+            // Issue #170: Shears are a valid alternative to the machete
+            // for thickets. Message stays in PT-BR (i18n via t() is wired
+            // elsewhere in the project; consistent with sibling strings).
+            case 'thicket': return 'facão ou tesoura';
             default: return null;
         }
     }
@@ -395,6 +403,10 @@ export class ItemSystem {
     getDropsFromAssetManager(type) {
         if (type === 'tree') return [{ id: 9, minQty: 2, maxQty: 5 }];
         if (type === 'rock') return [{ id: 10, minQty: 1, maxQty: 3 }];
+        // Issue #170: thicket dropped nothing — destroying with machete/shears
+        // produced no Plant Fiber (54). Now drops 1-3 fibers per thicket,
+        // matching the game's existing resource scarcity (similar to rocks).
+        if (type === 'thicket') return [{ id: 54, minQty: 1, maxQty: 3 }];
         return [];
     }
 

--- a/public/scripts/merchant.js
+++ b/public/scripts/merchant.js
@@ -130,7 +130,10 @@ class MerchantSystem {
                     { id: 13, name: 'Picareta', price: 80, category: 'tool', icon: '', quantity: 5 },
                     { id: 14, name: 'Machado', price: 60, category: 'tool', icon: '', quantity: 5 },
                     { id: 22, name: 'Machete', price: 55, category: 'tool', icon: '', quantity: 5 },
-                    { id: 16, name: 'Balde', price: 30, category: 'tool', icon: '', quantity: 10 }
+                    { id: 16, name: 'Balde', price: 30, category: 'tool', icon: '', quantity: 10 },
+                    // Issue #170: Shears (0) had no acquisition path — gating the
+                    // wool → fabric → chest chain. Added here so the loop closes.
+                    { id: 0,  name: 'Tesoura de jardinagem', price: 20, category: 'tool', icon: '', quantity: 5 }
                 ]
             },
             {

--- a/public/scripts/merchant.js
+++ b/public/scripts/merchant.js
@@ -854,6 +854,10 @@ class MerchantSystem {
     // obtém itens do mercador filtrados por categoria
     getMerchantItems() {
         let merchantItems = this.currentMerchant.items;
+        // Issue #170: hide items marked experimental — they have no loop in
+        // the game (no use, no consume), so letting players buy them would
+        // be misleading. When a feature unlocks them, drop the flag.
+        merchantItems = merchantItems.filter(mi => !getItem(mi.id)?.experimental);
         if (this.currentMerchantCategory !== 'all') {
             merchantItems = merchantItems.filter(item => item.category === this.currentMerchantCategory);
         }

--- a/public/scripts/recipes.js
+++ b/public/scripts/recipes.js
@@ -108,12 +108,17 @@ export const recipes = [
         icon: ""
     },
 
-    /* ferramentas */
+    /* Tools
+       Issue #170: Wooden Rod (76) was produced via `wooden_rod` but never
+       consumed — orphan output. Reused here as a tool handle. Since 1×
+       Plank yields 2× Rod, swapping plank for rod is balance-neutral but
+       closes the loop and reads better thematically (tool needs a handle). */
     {
         id: "axe",
         name: "Machado",
         requiredItems: [
-            { itemId: 58, qty: 2 },
+            { itemId: 76, qty: 1 },  // Wooden Rod (handle)
+            { itemId: 58, qty: 1 },  // Wooden Plank (structure)
             { itemId: 37, qty: 3 },
             { itemId: 35, qty: 1 }
         ],
@@ -126,7 +131,8 @@ export const recipes = [
         id: "pickaxe",
         name: "Picareta",
         requiredItems: [
-            { itemId: 58, qty: 2 },
+            { itemId: 76, qty: 1 },  // Wooden Rod (handle)
+            { itemId: 58, qty: 1 },  // Wooden Plank (structure)
             { itemId: 37, qty: 4 },
             { itemId: 35, qty: 1 }
         ],
@@ -139,7 +145,8 @@ export const recipes = [
         id: "hoe",
         name: "Enxada",
         requiredItems: [
-            { itemId: 58, qty: 2 },
+            { itemId: 76, qty: 1 },  // Wooden Rod (handle)
+            { itemId: 58, qty: 1 },  // Wooden Plank (structure)
             { itemId: 37, qty: 2 },
             { itemId: 35, qty: 1 }
         ],
@@ -152,7 +159,7 @@ export const recipes = [
         id: "scythe",
         name: "Foice",
         requiredItems: [
-            { itemId: 58, qty: 1 },
+            { itemId: 76, qty: 1 },  // Wooden Rod (handle only — scythe has no plank body)
             { itemId: 37, qty: 2 },
             { itemId: 35, qty: 1 }
         ],
@@ -181,7 +188,11 @@ export const recipes = [
         requiredItems: [
             { itemId: 58, qty: 8 },
             { itemId: 34, qty: 4 },
-            { itemId: 35, qty: 1 }
+            { itemId: 35, qty: 1 },
+            // Issue #170: Fabric (49) was produced via `wool_fabric` but
+            // never consumed. Added here as interior lining — pure flavor,
+            // doesn't change gameplay, just closes the loop.
+            { itemId: 49, qty: 1 }
         ],
         result: { itemId: 69, qty: 1 },
         category: "construction",
@@ -210,7 +221,11 @@ export const recipes = [
             { itemId: 10, qty: 25 },
             { itemId: 32, qty: 15 },
             { itemId: 73, qty: 6 },
-            { itemId: 75, qty: 12 },
+            // Issue #170: was Screw (75) qty: 12 — consolidated to Nail (34)
+            // to avoid confusing two functionally identical fasteners. Screw
+            // is marked experimental in item.js for possible future
+            // differentiation (e.g. durability tier).
+            { itemId: 34, qty: 12 },
             { itemId: 42, qty: 2 }
         ],
         result: { itemId: 103, qty: 1 },

--- a/public/scripts/thePlayer/inventoryUI.js
+++ b/public/scripts/thePlayer/inventoryUI.js
@@ -371,6 +371,159 @@ const createInventoryUI = () => {
       opacity: 0.9;
     }
 
+    /* Issue #170: technical info section between description and actions.
+       Built dynamically per item by _renderItemTechSection — each row,
+       bar, and badge is hidden when its data is absent. */
+    .inv-item-tech {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-top: 12px;
+      padding: 10px 14px;
+      background: rgba(20, 14, 8, 0.55);
+      border: 1px solid rgba(201, 164, 99, 0.25);
+      border-radius: 10px;
+    }
+    .inv-item-tech:empty { display: none; }
+
+    .inv-tech-title {
+      font-size: 11px;
+      font-weight: bold;
+      text-transform: uppercase;
+      letter-spacing: 0.6px;
+      color: #c9a463;
+      margin-bottom: 4px;
+    }
+
+    .inv-tech-row {
+      display: flex;
+      gap: 8px;
+      font-size: 13px;
+      align-items: baseline;
+    }
+
+    .inv-tech-label {
+      color: #c9a463;
+      font-weight: 600;
+      min-width: 100px;
+      flex-shrink: 0;
+    }
+
+    .inv-tech-value {
+      color: #f5e9d3;
+    }
+
+    /* Fill-up bars (hunger / thirst / energy) */
+    .inv-tech-fillup {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      margin-top: 2px;
+    }
+    .inv-tech-fillup-header {
+      margin-bottom: 2px;
+    }
+    .inv-tech-bar {
+      display: grid;
+      grid-template-columns: 80px 1fr 50px;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+    }
+    .inv-tech-bar-label {
+      color: #c9a463;
+    }
+    .inv-tech-bar-track {
+      position: relative;
+      height: 8px;
+      background: rgba(0, 0, 0, 0.45);
+      border-radius: 4px;
+      overflow: hidden;
+    }
+    .inv-tech-bar-fill {
+      display: block;
+      height: 100%;
+      transition: width 0.18s ease-out;
+    }
+    .inv-tech-bar-hunger .inv-tech-bar-fill { background: linear-gradient(90deg, #d9853d, #b06623); }
+    .inv-tech-bar-thirst .inv-tech-bar-fill { background: linear-gradient(90deg, #4ec0e8, #2e8db8); }
+    .inv-tech-bar-energy .inv-tech-bar-fill { background: linear-gradient(90deg, #f0c440, #c9982a); }
+    .inv-tech-bar-value {
+      color: #b6f5b6;
+      font-weight: bold;
+      text-align: right;
+    }
+
+    .inv-tech-experimental {
+      margin-top: 6px;
+      padding: 4px 8px;
+      background: rgba(180, 100, 30, 0.18);
+      border: 1px dashed rgba(220, 160, 80, 0.6);
+      border-radius: 6px;
+      color: #f0c060;
+      font-size: 11px;
+      font-weight: bold;
+      letter-spacing: 0.3px;
+      text-align: center;
+    }
+
+    .inv-tooltip {
+      position: absolute;
+      pointer-events: none;
+      max-width: 280px;
+      padding: 10px 12px;
+      background: linear-gradient(135deg, rgba(43, 26, 12, 0.97), rgba(59, 38, 18, 0.95));
+      border: 1px solid #8b5a2b;
+      border-radius: 8px;
+      box-shadow: 0 4px 14px rgba(0,0,0,0.5);
+      color: #f5e9d3;
+      font-size: 12px;
+      z-index: 9999;
+      transition: opacity 0.12s ease-out;
+    }
+    .inv-tooltip-name {
+      font-size: 13px;
+      font-weight: bold;
+      color: #f5e9d3;
+      margin-bottom: 3px;
+    }
+    .inv-tooltip-desc {
+      font-size: 11px;
+      color: #cfc1a3;
+      line-height: 1.35;
+      margin-bottom: 6px;
+    }
+    .inv-tooltip-meta {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      padding-top: 4px;
+      border-top: 1px solid rgba(201, 164, 99, 0.25);
+    }
+    .inv-tooltip-row {
+      display: flex;
+      gap: 6px;
+      font-size: 11px;
+    }
+    .inv-tooltip-row-label {
+      color: #c9a463;
+      font-weight: 600;
+    }
+    .inv-tooltip-row-value {
+      color: #f5e9d3;
+    }
+    .inv-tooltip-experimental {
+      margin-top: 6px;
+      padding: 3px 6px;
+      background: rgba(180, 100, 30, 0.18);
+      border: 1px dashed rgba(220, 160, 80, 0.6);
+      border-radius: 4px;
+      color: #f0c060;
+      font-size: 10px;
+      font-weight: bold;
+      text-align: center;
+    }
+
     .inv-actions {
       display: flex;
       gap: 12px;
@@ -594,12 +747,24 @@ const createInventoryUI = () => {
   detailDesc.className = 'inv-item-desc';
   detailDesc.id = 'detailDesc';
   itemInfo.append(detailName, detailDesc);
+  // Issue #170: technical info section (type, fillUp bars, toolType,
+  // medicine cure mode, etc.). Populated dynamically by updateDetailsPanel
+  // based on which fields exist on the selected item.
+  const detailTech = document.createElement('div');
+  detailTech.className = 'inv-item-tech';
+  detailTech.id = 'detailTech';
   const detailActions = document.createElement('div');
   detailActions.className = 'inv-actions';
   detailActions.id = 'detailActions';
-  details.append(itemInfo, detailActions);
+  details.append(itemInfo, detailTech, detailActions);
 
   contentDiv.append(grid, details);
+
+  const tooltip = document.createElement('div');
+  tooltip.className = 'inv-tooltip hidden';
+  tooltip.id = 'invTooltip';
+  contentDiv.appendChild(tooltip);
+
   bodyDiv.append(tabs, contentDiv);
   container.append(headerDiv, bodyDiv);
   overlay.appendChild(container);
@@ -887,7 +1052,6 @@ function renderInventory() {
       slotEl.appendChild(eqBadge);
     }
 
-    // Click handler
     slotEl.addEventListener('click', () => {
       const prevSelected = shadowRoot.querySelector('.inv-slot.selected');
       if (prevSelected) prevSelected.classList.remove('selected');
@@ -896,6 +1060,10 @@ function renderInventory() {
       selectedSlotIndex = index;
       updateDetailsPanel(fullItem, itemQuantity);
     });
+
+    slotEl.addEventListener('mouseenter', (e) => _showTooltip(fullItem, itemQuantity, e));
+    slotEl.addEventListener('mousemove', _positionTooltip);
+    slotEl.addEventListener('mouseleave', _hideTooltip);
 
     contentEl.appendChild(slotEl);
   });
@@ -913,6 +1081,228 @@ function renderInventory() {
   }
 }
 
+// Slim hover tooltip — name + description + a few key tech rows. Reuses
+// the same i18n keys as the side panel.
+function _showTooltip(item, qty, evt) {
+  if (!item) return;
+  const tip = shadowRoot.getElementById('invTooltip');
+  if (!tip) return;
+
+  tip.replaceChildren();
+
+  const name = document.createElement('div');
+  name.className = 'inv-tooltip-name';
+  name.textContent = `${getItemName(item.id, item.name)}${qty > 1 ? ` (x${qty})` : ''}`;
+  tip.appendChild(name);
+
+  if (item.description) {
+    const desc = document.createElement('div');
+    desc.className = 'inv-tooltip-desc';
+    desc.textContent = item.description;
+    tip.appendChild(desc);
+  }
+
+  const rows = [];
+  const typeLabel = t(`inventory.details.types.${item.type}`);
+  if (!typeLabel.startsWith('inventory.')) rows.push([t('inventory.details.type'), typeLabel]);
+
+  if (item.toolType) {
+    const tl = t(`controls.toolTypes.${item.toolType}`);
+    if (!tl.startsWith('controls.')) rows.push([t('inventory.details.toolType'), tl]);
+  }
+  if (item.fillUp) {
+    const parts = [];
+    for (const stat of ['hunger', 'thirst', 'energy']) {
+      const v = Number(item.fillUp[stat]) || 0;
+      if (v > 0) parts.push(`${t(`inventory.details.${stat}`)} +${v}`);
+    }
+    if (parts.length) rows.push([t('inventory.details.restores'), parts.join(' · ')]);
+  }
+  if (item.foodValue != null) rows.push([t('inventory.details.foodValue'), String(item.foodValue)]);
+
+  if (rows.length) {
+    const meta = document.createElement('div');
+    meta.className = 'inv-tooltip-meta';
+    for (const [label, value] of rows) {
+      const row = document.createElement('div');
+      row.className = 'inv-tooltip-row';
+      const l = document.createElement('span');
+      l.className = 'inv-tooltip-row-label';
+      l.textContent = `${label}:`;
+      const v = document.createElement('span');
+      v.className = 'inv-tooltip-row-value';
+      v.textContent = value;
+      row.append(l, v);
+      meta.appendChild(row);
+    }
+    tip.appendChild(meta);
+  }
+
+  if (item.experimental) {
+    const exp = document.createElement('div');
+    exp.className = 'inv-tooltip-experimental';
+    exp.textContent = `⚠ ${t('inventory.details.experimental')}`;
+    tip.appendChild(exp);
+  }
+
+  tip.classList.remove('hidden');
+  _positionTooltip(evt);
+}
+
+function _positionTooltip(evt) {
+  const tip = shadowRoot.getElementById('invTooltip');
+  if (!tip || tip.classList.contains('hidden')) return;
+  const parent = tip.offsetParent || tip.parentElement;
+  if (!parent) return;
+  const rect = parent.getBoundingClientRect();
+  tip.style.left = `${evt.clientX - rect.left + 14}px`;
+  tip.style.top = `${evt.clientY - rect.top + 14}px`;
+}
+
+function _hideTooltip() {
+  const tip = shadowRoot.getElementById('invTooltip');
+  if (tip) tip.classList.add('hidden');
+}
+
+/**
+ * Renders the "Technical info" section of the details panel based on which
+ * fields exist on the selected item. Each block is gated by an `if` so an
+ * item only shows the rows it actually has data for.
+ *
+ * Sections (in order):
+ *   1. Type (always)
+ *   2. Tool type (if `item.toolType`)
+ *   3. Fill-up bars (if `item.fillUp` — food/water)
+ *   4. Animal food details (if `type === 'animal_food'`)
+ *   5. Medicine details (if `type === 'medicine'`)
+ *   6. Placeable size (if `item.placeable` with buildWidth/Height)
+ *   7. Experimental badge (if `item.experimental`)
+ *
+ * Issue #170.
+ *
+ * @param {HTMLElement} container - The `#detailTech` element to populate.
+ * @param {object} item - The full item object (from `items.js`).
+ * @returns {void}
+ */
+function _renderItemTechSection(container, item) {
+  container.replaceChildren();
+  if (!item) return;
+
+  // Section title
+  const title = document.createElement('div');
+  title.className = 'inv-tech-title';
+  title.textContent = t('inventory.details.sectionTitle');
+  container.appendChild(title);
+
+  const addRow = (labelKey, valueText) => {
+    if (valueText === '' || valueText == null) return;
+    const row = document.createElement('div');
+    row.className = 'inv-tech-row';
+    const label = document.createElement('span');
+    label.className = 'inv-tech-label';
+    label.textContent = `${t(labelKey)}:`;
+    const value = document.createElement('span');
+    value.className = 'inv-tech-value';
+    value.textContent = valueText;
+    row.append(label, value);
+    container.appendChild(row);
+  };
+
+  // 1. Type — always shown
+  const typeLabel = t(`inventory.details.types.${item.type}`);
+  // i18n fallback: if the type key is missing, fall back to the raw type.
+  addRow('inventory.details.type', typeLabel.startsWith('inventory.') ? item.type : typeLabel);
+
+  // 2. Tool type
+  if (item.toolType) {
+    const toolLabel = t(`controls.toolTypes.${item.toolType}`);
+    addRow('inventory.details.toolType', toolLabel.startsWith('controls.') ? item.toolType : toolLabel);
+  }
+
+  // 3. Fill-up bars (food/consumable)
+  if (item.fillUp) {
+    const bars = document.createElement('div');
+    bars.className = 'inv-tech-fillup';
+    const restoresLabel = document.createElement('div');
+    restoresLabel.className = 'inv-tech-label inv-tech-fillup-header';
+    restoresLabel.textContent = `${t('inventory.details.restores')}:`;
+    bars.appendChild(restoresLabel);
+    for (const stat of ['hunger', 'thirst', 'energy']) {
+      const v = Number(item.fillUp[stat]) || 0;
+      if (v <= 0) continue;
+      const barWrap = document.createElement('div');
+      barWrap.className = `inv-tech-bar inv-tech-bar-${stat}`;
+      const barLabel = document.createElement('span');
+      barLabel.className = 'inv-tech-bar-label';
+      barLabel.textContent = t(`inventory.details.${stat}`);
+      const barTrack = document.createElement('span');
+      barTrack.className = 'inv-tech-bar-track';
+      const barFill = document.createElement('span');
+      barFill.className = 'inv-tech-bar-fill';
+      barFill.style.width = `${Math.min(100, v)}%`;
+      barTrack.appendChild(barFill);
+      const barValue = document.createElement('span');
+      barValue.className = 'inv-tech-bar-value';
+      barValue.textContent = `+${v}`;
+      barWrap.append(barLabel, barTrack, barValue);
+      bars.appendChild(barWrap);
+    }
+    container.appendChild(bars);
+  }
+
+  // 4. Animal food
+  if (item.type === 'animal_food') {
+    if (item.foodValue != null) {
+      addRow('inventory.details.foodValue', String(item.foodValue));
+    }
+    if (item.targetAnimals && item.targetAnimals !== 'all' && Array.isArray(item.targetAnimals) && item.targetAnimals.length) {
+      const names = item.targetAnimals.map((asset) => {
+        const key = `animals.${asset.toLowerCase()}`;
+        const tr = t(key);
+        return tr.startsWith('animals.') ? asset : tr;
+      });
+      addRow('inventory.details.acceptedBy', names.join(', '));
+    } else if (item.targetAnimals === 'all') {
+      addRow('inventory.details.acceptedBy', '★');
+    }
+  }
+
+  // 5. Medicine
+  if (item.type === 'medicine') {
+    if (item.targetDisease) {
+      const dk = `inventory.details.diseases.${item.targetDisease}`;
+      const dt = t(dk);
+      addRow('inventory.details.treats', dt.startsWith('inventory.') ? item.targetDisease : dt);
+    }
+    if (item.cureMode === 'instant') {
+      addRow('inventory.details.cureMode', t('inventory.details.instant'));
+    } else if (item.cureMode === 'gradual' && item.daysToCure) {
+      addRow('inventory.details.cureMode', t('inventory.details.gradual').replace('{n}', item.daysToCure));
+    }
+    if (item.dosesPerDay) {
+      addRow('inventory.details.dosesPerDay', String(item.dosesPerDay));
+    }
+    if (item.palatability) {
+      const pk = `inventory.details.${item.palatability}`;
+      const pt = t(pk);
+      addRow('inventory.details.palatability', pt.startsWith('inventory.') ? item.palatability : pt);
+    }
+  }
+
+  // 6. Placeable size
+  if (item.placeable && item.buildWidth && item.buildHeight) {
+    addRow('inventory.details.size', `${item.buildWidth} × ${item.buildHeight}`);
+  }
+
+  // 7. Experimental badge — show at the end
+  if (item.experimental) {
+    const badge = document.createElement('div');
+    badge.className = 'inv-tech-experimental';
+    badge.textContent = `⚠ ${t('inventory.details.experimental')}`;
+    container.appendChild(badge);
+  }
+}
+
 /**
  * Atualiza o painel lateral de detalhes do item selecionado (nome,
  * descrição, botões de ação).
@@ -921,6 +1311,9 @@ function renderInventory() {
  * e "Desequipar" (verde) baseado em `playerSystem.getEquippedItem()`.
  * Click em Equipar dispara `equipItemRequest`; click em Desequipar
  * dispara `unequipItemRequest`. Em ambos os casos o inventário fecha.
+ *
+ * Issue #170: also renders the technical info section via
+ * `_renderItemTechSection` based on item fields (type, fillUp, etc.).
  *
  * Se `item` for null/undefined, esconde o painel (`.hidden`) e retorna.
  *
@@ -940,7 +1333,11 @@ function updateDetailsPanel(item, qty) {
   const itemName = getItemName(item.id, item.name);
   shadowRoot.getElementById('detailName').textContent = `${itemName} ${qty > 1 ? `(x${qty})` : ''}`;
   shadowRoot.getElementById('detailDesc').textContent = item.description || t('inventory.noDescription');
-  
+
+  // Issue #170: technical info section (dynamic per-field).
+  const techDiv = shadowRoot.getElementById('detailTech');
+  if (techDiv) _renderItemTechSection(techDiv, item);
+
   const actionsDiv = shadowRoot.getElementById('detailActions');
   // fix: innerHTML → DOM API
   actionsDiv.replaceChildren();
@@ -985,7 +1382,16 @@ function updateDetailsPanel(item, qty) {
       logger.debug(`🔨 Iniciando construção: ${item.name}`);
       closeInventoryModal();
 
-      // Usar getSystem (legacy bridge já garante compatibilidade)
+      // chestSystem/wellSystem load lazily on first interaction in the world.
+      // If the player crafts and tries to place one BEFORE ever interacting
+      // with an existing chest/well, getSystem('chest'|'well') is null at
+      // placeObject() time and the build bails silently. Pre-load them here.
+      if (item.id === 69) {
+        try { await import('../chestSystem.js'); } catch (e) { logger.warn('chestSystem preload failed', e); }
+      } else if (item.id === 93) {
+        try { await import('../wellSystem.js'); } catch (e) { logger.warn('wellSystem preload failed', e); }
+      }
+
       let BuildSystem = getSystem('build');
 
       if (BuildSystem) {

--- a/public/scripts/thePlayer/inventoryUI.js
+++ b/public/scripts/thePlayer/inventoryUI.js
@@ -915,6 +915,7 @@ export function closeInventoryModal() {
   if (modalEl) {
     modalEl.classList.remove('open');
   }
+  _hideTooltip();
   selectedSlotIndex = -1;
   updateDetailsPanel(null);
 
@@ -978,6 +979,7 @@ function renderTabs() {
 function renderInventory() {
   if (!contentEl) return;
 
+  _hideTooltip();
   // fix: innerHTML → DOM API
   contentEl.replaceChildren();
 
@@ -1382,14 +1384,13 @@ function updateDetailsPanel(item, qty) {
       logger.debug(`🔨 Iniciando construção: ${item.name}`);
       closeInventoryModal();
 
-      // chestSystem/wellSystem load lazily on first interaction in the world.
-      // If the player crafts and tries to place one BEFORE ever interacting
-      // with an existing chest/well, getSystem('chest'|'well') is null at
-      // placeObject() time and the build bails silently. Pre-load them here.
+      // chestSystem loads lazily on first chest interaction in the world. If
+      // the player crafts and tries to place one before ever interacting with
+      // an existing chest, getSystem('chest') is null at placeObject() time
+      // and the build bails silently. Pre-load here. wellSystem is already
+      // statically imported by buildSystem.js, no pre-load needed.
       if (item.id === 69) {
         try { await import('../chestSystem.js'); } catch (e) { logger.warn('chestSystem preload failed', e); }
-      } else if (item.id === 93) {
-        try { await import('../wellSystem.js'); } catch (e) { logger.warn('wellSystem preload failed', e); }
       }
 
       let BuildSystem = getSystem('build');


### PR DESCRIPTION
  fix #170 
  
- Wire Wooden Rod/Fabric/Shears, flag 9 dormant items as experimental
  - Fix sheep feed missing foodValue + thicket drop bug
  - Inventory details panel + hover tooltip + i18n (pt/en/es)
  - Eager-load chestSystem/wellSystem so Baú/Poço can be placed 
  - Filter experimental items from merchant 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Shears can now be used as an alternative tool for pruning thickets
  * Inventory panel now displays detailed technical information for items (type, durability restores, food/medicine properties)

* **Bug Fixes**
  * Fixed missing nutrition data for sheep feed
  * Experimental items no longer appear in merchant inventory
  * Improved system loading for chest and well placement

* **Balance Updates**
  * Adjusted tool crafting recipes to use wooden rod handles more consistently
  * Thickets now drop plant fiber (1–3 quantity)
  * Updated storage chest and water trough crafting requirements for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->