### PR TITLE
perf: skip redundant localStorage write on save load

### DIFF
--- a/public/scripts/saveSystem.js
+++ b/public/scripts/saveSystem.js
@@ -497,9 +497,14 @@ class SaveSystem {
 
             // Run migrations on old saves
             if (slot.data) {
+                const beforeVersion = slot.data._dataVersion || 1;
                 slot.data = migrateSaveData(slot.data);
-                // Persist migrated data so we don't re-migrate next time
-                this._writeRoot(root);
+                // Persist only when a migration actually bumped the data version.
+                // Otherwise loadSlot() rewrote localStorage on every load even
+                // though nothing changed (#183).
+                if ((slot.data._dataVersion || 1) !== beforeVersion) {
+                    this._writeRoot(root);
+                }
             }
 
             // Selecionar como ativo


### PR DESCRIPTION
fix #183 


loadSlot() persisted migrated data inside `if (slot.data)`, which is always true.
This caused localStorage to be rewritten on every load even when no migration ran.

Root Cause

Write was not conditional on actual data version changes.

Fix
---
Gate the _writeRoot() call on the data version actually changing.
The write should only happen when a migration bumped _dataVersion.

Impact

Prevents unnecessary localStorage writes when loading saves that don't require migration.