### PR TITLE
fixed the duplicate

### DIFF
--- a/public/scripts/saveSystem.js
+++ b/public/scripts/saveSystem.js
@@ -225,23 +225,31 @@ class SaveSystem {
         this.autoSaveInterval = null;
         this.isDirty = false;
         this._cachedRoot = null; // Cache para otimização
+        this._lastExitSaveAt = 0; // dedupe for the exit-save pair (#178)
 
         // Registrar no gameState
         registerSystem('save', this);
 
-        // Salvar antes de fechar a página
+        // Salvar antes de fechar a página. Tanto `visibilitychange->hidden`
+        // quanto `beforeunload` disparam ao fechar a aba (com ms de diferença);
+        // sem dedupe isso fazia DOIS _gatherGameData() completos (exporta o
+        // mundo inteiro) de uma vez (#178). Esta janela curta colapsa o par,
+        // mas ainda salva normalmente num hide/close genuíno mais tarde.
             if (typeof window !== 'undefined') {
-                window.addEventListener('beforeunload', () => {
-                if (this.activeSlot !== null) {
-                    this.saveActive('beforeunload');
-                }
-            });
+                const EXIT_SAVE_DEBOUNCE_MS = 2000;
+                const saveOnExit = (reason) => {
+                    if (this.activeSlot === null) return;
+                    const now = Date.now();
+                    if (now - this._lastExitSaveAt < EXIT_SAVE_DEBOUNCE_MS) return;
+                    this._lastExitSaveAt = now;
+                    this.saveActive(reason);
+                };
 
-            document.addEventListener('visibilitychange', () => {
-                if (document.visibilityState === 'hidden' && this.activeSlot !== null) {
-                    this.saveActive('visibilitychange');
-                }
-            });
+                window.addEventListener('beforeunload', () => saveOnExit('beforeunload'));
+
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'hidden') saveOnExit('visibilitychange');
+                });
 
              window.addEventListener('storage', (e) => {
                 if (e.key === ROOT_KEY || e.key === null) {


### PR DESCRIPTION
fix #178 

  The constructor registered both `beforeunload` and `visibilitychange → hidden`, each calling `saveActive()`. Closing a tab fires both (milliseconds apart), so  the game ran two full `_gatherGameData()` passes back-to-back — each exports the
entire world — for a single close.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate save operations when the page is closed or becomes hidden, reducing unnecessary work, improving exit performance, and lowering the risk of save conflicts or lost progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->