### PR TITLE
 fix: merge into window.__debug in exposeDebug instead of recreating

### DIFF
--- a/public/scripts/gameState.js
+++ b/public/scripts/gameState.js
@@ -160,13 +160,18 @@ export function exposeDebug(extra = {}) {
   if (typeof window === "undefined") return;
   if (!getDebugFlag("debug")) return;
 
-  window.__debug = {
+  // Merge into the existing object instead of recreating it. Other systems
+  // (foodTroughSystem, waterTroughSystem) attach devtools helpers via
+  // `window.__debug = window.__debug || {}`; recreating here would clobber
+  // them depending on init order (#176).
+  window.__debug = window.__debug || {};
+  Object.assign(window.__debug, {
     systems: gameState.systems,
     objects: gameState.objects,
     debugFlags: gameState.debug,
     flags: gameState.flags,
     extra, // Namespaced to prevent override of core properties
-  };
+  });
 }
 
 /**


### PR DESCRIPTION
fix #176 

Bug Fix: exposeDebug Overwrites Devtools Helpers on window.__debug


Problem
`exposeDebug()` in gameState.js did `window.__debug = { ... }`, recreating the object. 
But foodTroughSystem/waterTroughSystem attach devtools helpers via 
`window.__debug = window.__debug || {}`.

Fix
exposeDebug now merges into the existing object instead of recreating it:
`window.__debug = window.__debug || {}; Object.assign(window.__debug, {...})`

Result
The trough systems already use the safe merge pattern, so both init orders are now correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue where debug helpers and devtools data were being lost during initialization. Debug data now properly merges with existing information, ensuring all debugging utilities remain accessible throughout the application lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->