### PR TITLE
test: assert i18n key parity across en/es/pt-BR

### DIFF
--- a/public/scripts/i18n/pt-BR.js
+++ b/public/scripts/i18n/pt-BR.js
@@ -1096,6 +1096,12 @@ export default {
     wellError: 'erro ao colocar poço',
     wellLoading: 'sistema de poços carregando...',
     placed: 'colocado! ({remaining} restante)',
+    placeError: 'erro ao posicionar objeto',
+    worldNotAvailable: 'erro: theWorld.addWorldObject indisponível',
+    variant: 'variante: {name}',
+    notAvailable: 'Função de construção não disponível.',
+    notAvailableAfter: 'Função de construção não disponível após carregar.',
+    buildError: 'Erro ao entrar no modo construção. Verifique o console.',
     // Novas adições do sistema Q + pickup (cercado)
     emptyHint: 'Modo construção — Q troca item, clique pega cerca',
     pickedUp: 'Pegou cerca (×{qty}) — clique pra colocar',

--- a/tests/unit/i18nParity.test.js
+++ b/tests/unit/i18nParity.test.js
@@ -1,0 +1,47 @@
+import { describe, test, expect } from 'bun:test';
+import en from '../../public/scripts/i18n/en.js';
+import es from '../../public/scripts/i18n/es.js';
+import ptBR from '../../public/scripts/i18n/pt-BR.js';
+
+/**
+ * Flattens a nested translation dictionary into the set of leaf key paths,
+ * e.g. "npc.couple.jeremyIntro". Arrays are treated as leaves (their shape is
+ * the value, not more key paths).
+ */
+function keyPaths(obj, prefix = '', out = new Set()) {
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      keyPaths(value, path, out);
+    } else {
+      out.add(path);
+    }
+  }
+  return out;
+}
+
+// English is the reference locale; es/pt-BR must match its key paths exactly.
+const enKeys = keyPaths(en);
+const otherLocales = { es, 'pt-BR': ptBR };
+
+describe('i18n key parity across locales (en/es/pt-BR)', () => {
+  for (const [name, dict] of Object.entries(otherLocales)) {
+    const keys = keyPaths(dict);
+
+    test(`${name} is not missing any key present in en`, () => {
+      const missing = [...enKeys].filter((k) => !keys.has(k)).sort();
+      expect(missing).toEqual([]);
+    });
+
+    test(`${name} has no key absent from en`, () => {
+      const extra = [...keys].filter((k) => !enKeys.has(k)).sort();
+      expect(extra).toEqual([]);
+    });
+  }
+
+  test('all three locales have the same number of key paths', () => {
+    expect(keyPaths(es).size).toBe(enKeys.size);
+    expect(keyPaths(ptBR).size).toBe(enKeys.size);
+  });
+});


### PR DESCRIPTION
i18n Fix: Locale Key Parity + Regression Test

fix #175 

Problem

Key paths diverged: pt-BR was missing 6 `build.*` keys that en/es had:
- placeError
- worldNotAvailable  
- variant
- notAvailable
- notAvailableAfter
- buildError

Fix
---
Added the missing pt-BR translations so all three locales share an identical set of key paths.

Prevention

Added `tests/unit/i18nParity.test.js`: flattens each dictionary to leaf key paths 
and asserts es/pt-BR match en exactly. Checks for no missing keys, no extra keys, same count.
This ensures locale drift can't regress silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Brazilian Portuguese language support with new translations for construction-mode error handling, including messages for placement failures, world unavailability, and build-function status notifications.

* **Tests**
  * Implemented automated test to enforce translation key consistency across all supported locales, ensuring completeness and parity in future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->