### PR TITLE
refactor: animal render/update helpers + shared trough slot module

### DIFF
--- a/public/scripts/animal/animalAI.js
+++ b/public/scripts/animal/animalAI.js
@@ -344,6 +344,30 @@ function pickGenderFor(assetName) {
     return Math.random() < 0.5 ? 'male' : 'female';
 }
 
+// Palettes for `_drawNeedBar` (thirst/hunger bars). Module-level constants so
+// the hot draw path allocates nothing per frame (mirrors the getHitbox pooling
+// philosophy). `waterFX` adds the drinking-only shine + rising bubbles.
+const NEED_BAR_THIRST = {
+    icon: '💧', iconColor: '#cde9ff',
+    bgGrad: ['rgba(8, 20, 38, 0.85)', 'rgba(4, 12, 24, 0.85)'],
+    bgFlat: 'rgba(6, 16, 30, 0.85)',
+    fill: ['#9be3ff', '#5bbcff', '#2d7ec8'], fillFlat: '#5bbcff',
+    glow: [123, 200, 255], glowAlpha: 0.55, glowPulse: true,
+    outline: ['rgba(255, 230, 180, 0.7)', 'rgba(255, 230, 180, 0.4)'],
+    halo: ['rgba(120, 200, 255, 0.22)', 'rgba(120, 200, 255, 0)'],
+    waterFX: true,
+};
+const NEED_BAR_HUNGER = {
+    icon: '🌾', iconColor: '#f4e2b0',
+    bgGrad: null, // flat bg for both quality modes
+    bgFlat: 'rgba(28, 20, 6, 0.85)',
+    fill: ['#f6d878', '#d9a441', '#a8761f'], fillFlat: '#d9a441',
+    glow: [216, 178, 90], glowAlpha: 0.5, glowPulse: false,
+    outline: ['rgba(255, 230, 180, 0.7)', 'rgba(255, 230, 180, 0.4)'],
+    halo: ['rgba(216, 178, 90, 0.22)', 'rgba(216, 178, 90, 0)'],
+    waterFX: false,
+};
+
 export class AnimalEntity {
     constructor(assetName, assetData, x, y, opts = {}) {
         // Id estável desde a construção. theWorld atribui o id real do
@@ -695,6 +719,288 @@ export class AnimalEntity {
         ctx.lineTo(x, y + rr);
         ctx.quadraticCurveTo(x, y, x + rr, y);
         ctx.closePath();
+    }
+
+    /**
+     * Draws a "need" bar (thirst/hunger) above the animal. Shared skeleton for
+     * the DRINKING and EATING flows — geometry + FX are identical, only the
+     * palette/icon differ (see NEED_BAR_THIRST / NEED_BAR_HUNGER). Keeping this
+     * in one place removed ~100 lines of near-duplicate bar rendering.
+     * @param {CanvasRenderingContext2D} ctx
+     * @param {Object} camera
+     * @param {{x:number,y:number}} screenPos - animal top-left on screen
+     * @param {number} zoomedWidth
+     * @param {number} zoomedHeight
+     * @param {number} now - timestamp for animated FX
+     * @param {Object} pal - palette (NEED_BAR_THIRST | NEED_BAR_HUNGER)
+     * @param {number} pct - fill ratio 0..1
+     */
+    _drawNeedBar(ctx, camera, screenPos, zoomedWidth, zoomedHeight, now, pal, pct) {
+        // Quality mode: low = barra básica (fill simples + outline). Medium/high
+        // = todos os FX (halo, gradient, glow, e shine/bolhas no waterFX).
+        const heavyFX = qualityMode.enableHeavyFX;
+        const barW = Math.max(36, this.width * 0.75) * camera.zoom;
+        const barH = 6 * camera.zoom;
+        const radius = barH / 2;
+        const bx = Math.floor(screenPos.x + (zoomedWidth - barW) / 2);
+        const by = Math.floor(screenPos.y - 14 * camera.zoom);
+        const fillW = Math.max(0, Math.round(barW * Math.max(0, Math.min(1, pct))));
+
+        ctx.save();
+
+        // Halo radial sob o animal (HEAVY — radialGradient é caro).
+        if (heavyFX && pal.halo) {
+            const haloX = screenPos.x + zoomedWidth / 2;
+            const haloY = screenPos.y + zoomedHeight - 4 * camera.zoom;
+            const haloR = Math.max(zoomedWidth, zoomedHeight) * 0.45;
+            const halo = ctx.createRadialGradient(haloX, haloY, 0, haloX, haloY, haloR);
+            halo.addColorStop(0, pal.halo[0]);
+            halo.addColorStop(1, pal.halo[1]);
+            ctx.fillStyle = halo;
+            ctx.beginPath();
+            ctx.arc(haloX, haloY, haloR, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        // Ícone antes da barra (sempre — é só um texto).
+        const iconBounce = heavyFX ? Math.sin(now / 200) * 1.5 * camera.zoom : 0;
+        ctx.font = `${Math.round(11 * camera.zoom)}px sans-serif`;
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'middle';
+        if (heavyFX) {
+            ctx.shadowColor = 'rgba(0, 0, 0, 0.55)';
+            ctx.shadowBlur = 3 * camera.zoom;
+        }
+        ctx.fillStyle = pal.iconColor;
+        ctx.fillText(pal.icon, bx - 3 * camera.zoom, by + barH / 2 + iconBounce);
+        ctx.shadowBlur = 0;
+
+        // Fundo — gradient no high (se pal.bgGrad), cor sólida no low.
+        if (heavyFX && pal.bgGrad) {
+            const bgGrad = ctx.createLinearGradient(bx, by, bx, by + barH);
+            bgGrad.addColorStop(0, pal.bgGrad[0]);
+            bgGrad.addColorStop(1, pal.bgGrad[1]);
+            ctx.fillStyle = bgGrad;
+        } else {
+            ctx.fillStyle = pal.bgFlat;
+        }
+        this._roundRect(ctx, bx, by, barW, barH, radius);
+        ctx.fill();
+
+        // Preenchimento — gradient + glow no high, fill simples no low.
+        if (fillW > 1) {
+            if (heavyFX) {
+                const pulse = pal.glowPulse ? (0.85 + 0.15 * Math.sin(now / 180)) : 1;
+                const fillGrad = ctx.createLinearGradient(bx, by, bx, by + barH);
+                fillGrad.addColorStop(0, pal.fill[0]);
+                fillGrad.addColorStop(0.5, pal.fill[1]);
+                fillGrad.addColorStop(1, pal.fill[2]);
+                ctx.fillStyle = fillGrad;
+                ctx.shadowColor = `rgba(${pal.glow[0]}, ${pal.glow[1]}, ${pal.glow[2]}, ${pal.glowAlpha * pulse})`;
+                ctx.shadowBlur = 8 * camera.zoom;
+                this._roundRect(ctx, bx, by, fillW, barH, radius);
+                ctx.fill();
+                ctx.shadowBlur = 0;
+            } else {
+                ctx.fillStyle = pal.fillFlat;
+                this._roundRect(ctx, bx, by, fillW, barH, radius);
+                ctx.fill();
+            }
+        }
+
+        // Contorno (sempre — barato).
+        ctx.strokeStyle = heavyFX ? pal.outline[0] : pal.outline[1];
+        ctx.lineWidth = Math.max(1, camera.zoom);
+        this._roundRect(ctx, bx, by, barW, barH, radius);
+        ctx.stroke();
+
+        // FX exclusivo da água: shine atravessando + bolhas subindo.
+        if (heavyFX && pal.waterFX && fillW > 1) {
+            const shineX = bx + ((now / 12) % (barW + 20)) - 10;
+            if (shineX > bx && shineX < bx + fillW - 4) {
+                const shineGrad = ctx.createLinearGradient(shineX - 6, 0, shineX + 6, 0);
+                shineGrad.addColorStop(0, 'rgba(255, 255, 255, 0)');
+                shineGrad.addColorStop(0.5, 'rgba(255, 255, 255, 0.55)');
+                shineGrad.addColorStop(1, 'rgba(255, 255, 255, 0)');
+                ctx.fillStyle = shineGrad;
+                ctx.fillRect(shineX - 6, by + 1, 12, barH - 2);
+            }
+            if (fillW > 6) {
+                ctx.fillStyle = 'rgba(255, 255, 255, 0.55)';
+                for (let i = 0; i < 3; i++) {
+                    const phase = (now / 600 + i * 0.33) % 1;
+                    const bbX = bx + 4 * camera.zoom + (i * (fillW - 10) / 3);
+                    const bbY = by + barH - phase * (barH - 2);
+                    if (bbX < bx + fillW - 2) {
+                        ctx.beginPath();
+                        ctx.arc(bbX, bbY, 1 * camera.zoom, 0, Math.PI * 2);
+                        ctx.fill();
+                    }
+                }
+            }
+        }
+
+        ctx.restore();
+    }
+
+    /**
+     * Floating need emote (💧 sede / 🍽️ fome) above the animal — feedback that
+     * it needs something before it starts consuming. Bobbing + a stronger pulse
+     * while it's already seeking the trough.
+     */
+    _drawNeedEmote(ctx, camera, screenPos, zoomedWidth, now, emoji, isSeeking) {
+        const bob = Math.sin(now / 280) * 2.5 * camera.zoom;
+        ctx.save();
+        ctx.font = `${Math.round(15 * camera.zoom)}px sans-serif`;
+        ctx.textAlign = 'center';
+        ctx.shadowColor = 'rgba(0, 0, 0, 0.65)';
+        ctx.shadowBlur = 4 * camera.zoom;
+        ctx.globalAlpha = isSeeking ? (0.65 + 0.35 * Math.abs(Math.sin(now / 220))) : 0.85;
+        ctx.fillText(
+            emoji,
+            Math.floor(screenPos.x + zoomedWidth / 2),
+            Math.floor(screenPos.y - 30 * camera.zoom + bob),
+        );
+        ctx.restore();
+    }
+
+    /**
+     * Floating collect FX (gather success/failure). Rises ~18px and fades over
+     * ~1.5s, then clears itself. No-op when there's no active FX.
+     */
+    _drawCollectFx(ctx, camera, screenPos, zoomedWidth, now) {
+        const fx = this._collectFx;
+        if (!fx) return;
+        const elapsed = now - fx.startedAt;
+        const duration = fx.duration || 1500;
+        if (elapsed >= duration) {
+            this._collectFx = null;
+            return;
+        }
+        const t = elapsed / duration;
+        ctx.save();
+        ctx.globalAlpha = 1 - t;
+        ctx.font = `bold ${Math.round(12 * camera.zoom)}px sans-serif`;
+        ctx.textAlign = 'center';
+        ctx.lineWidth = 3 * camera.zoom;
+        ctx.strokeStyle = '#fff';
+        ctx.fillStyle = fx.success ? '#1f8b3a' : '#b73030';
+        const tx = Math.floor(screenPos.x + zoomedWidth / 2);
+        const ty = Math.floor(screenPos.y + (-34 - t * 18) * camera.zoom);
+        ctx.strokeText(fx.text, tx, ty);
+        ctx.fillText(fx.text, tx, ty);
+        ctx.restore();
+    }
+
+    /** Draws the animal sprite (mirrored when flipX), one frame from the sheet. */
+    _drawSprite(ctx, screenPos, zoomedWidth, zoomedHeight) {
+        const sx = this.frameIndex * this.frameWidth;
+        const sy = this.direction * this.frameHeight;
+        const drawX = Math.floor(screenPos.x);
+        const drawY = Math.floor(screenPos.y);
+        if (this.flipX) {
+            // Translada pro canto direito e inverte X — o sprite desenhado
+            // em (0,0) cai exatamente no lugar de antes, só espelhado.
+            ctx.save();
+            ctx.translate(drawX + zoomedWidth, drawY);
+            ctx.scale(-1, 1);
+            ctx.drawImage(this.img, sx, sy, this.frameWidth, this.frameHeight, 0, 0, zoomedWidth, zoomedHeight);
+            ctx.restore();
+        } else {
+            ctx.drawImage(this.img, sx, sy, this.frameWidth, this.frameHeight, drawX, drawY, zoomedWidth, zoomedHeight);
+        }
+    }
+
+    /** Mood emoji just above the sprite (skipped when CALM). */
+    _drawMoodEmoji(ctx, camera, screenPos, zoomedWidth) {
+        if (this._mood === AnimalMood.CALM) return;
+        const emoji = this.moodEmoji;
+        if (!emoji) return;
+        ctx.save();
+        ctx.font = `${Math.round(14 * camera.zoom)}px sans-serif`;
+        ctx.textAlign = 'center';
+        ctx.fillText(emoji, Math.floor(screenPos.x + zoomedWidth / 2), Math.floor(screenPos.y - 4 * camera.zoom));
+        ctx.restore();
+    }
+
+    /**
+     * "Product ready" indicator (🥛/🧶/🥚) above the mood emoji, with a soft
+     * bounce. Visible in any mood (a sleeping animal can have an egg ready).
+     */
+    _drawPendingProduct(ctx, camera, screenPos, zoomedWidth, now) {
+        if (!this._pendingProduct) return;
+        const productEmoji = PRODUCT_EMOJI[this._pendingProduct] || '✨';
+        const bounce = Math.sin(now / 250) * 2 * camera.zoom;
+        ctx.save();
+        ctx.font = `${Math.round(16 * camera.zoom)}px sans-serif`;
+        ctx.textAlign = 'center';
+        ctx.fillText(productEmoji, Math.floor(screenPos.x + zoomedWidth / 2), Math.floor(screenPos.y - 20 * camera.zoom + bounce));
+        ctx.restore();
+    }
+
+    /**
+     * Age-up FX: "Cresceu!" text + 4 orbiting sparkles, ~2.5s. Clears itself
+     * when expired. No-op when there's no active FX.
+     */
+    _drawAgeUpFx(ctx, camera, screenPos, zoomedWidth, zoomedHeight, now) {
+        const fx = this._ageUpFx;
+        if (!fx) return;
+        const elapsed = now - fx.startedAt;
+        const duration = fx.duration || 2500;
+        if (elapsed >= duration) {
+            this._ageUpFx = null;
+            return;
+        }
+        const t = elapsed / duration;
+        ctx.save();
+        ctx.globalAlpha = 1 - Math.pow(t, 2);  // fade out quadrático
+
+        // Texto "Cresceu!" pulsando acima.
+        const pulse = 1 + 0.15 * Math.sin(elapsed / 100);
+        ctx.font = `bold ${Math.round(13 * camera.zoom * pulse)}px sans-serif`;
+        ctx.textAlign = 'center';
+        ctx.lineWidth = 3 * camera.zoom;
+        ctx.strokeStyle = '#fff';
+        ctx.fillStyle = '#d4a017';
+        const tx = Math.floor(screenPos.x + zoomedWidth / 2);
+        const ty = Math.floor(screenPos.y - 32 * camera.zoom - t * 12 * camera.zoom);
+        ctx.strokeText(fx.text || '✨', tx, ty);
+        ctx.fillText(fx.text || '✨', tx, ty);
+
+        // 4 sparkles orbitando o sprite (rotação simples).
+        ctx.font = `${Math.round(14 * camera.zoom)}px sans-serif`;
+        const cx = screenPos.x + zoomedWidth / 2;
+        const cy = screenPos.y + zoomedHeight / 2;
+        const radius = (zoomedWidth + zoomedHeight) / 2 * (0.6 + t * 0.3);
+        const angleBase = elapsed / 200;
+        for (let i = 0; i < 4; i++) {
+            const ang = angleBase + i * Math.PI / 2;
+            ctx.fillText('✨', Math.floor(cx + Math.cos(ang) * radius), Math.floor(cy + Math.sin(ang) * radius));
+        }
+        ctx.restore();
+    }
+
+    /**
+     * Debug overlay of the interaction (reach) hitbox — `?hitboxes=1`. Green
+     * when it currently intersects something interactable, orange otherwise.
+     */
+    _drawHitboxDebug(ctx, camera) {
+        if (!getDebugFlag('hitboxes')) return;
+        const ih = this.getInteractionHitbox();
+        const sp = camera.worldToScreen(ih.x, ih.y);
+        const zoom = camera.zoom || 1;
+        ctx.save();
+        ctx.lineWidth = 2;
+        if (this._interactionActive) {
+            ctx.strokeStyle = 'rgba(80, 220, 100, 0.95)';
+            ctx.fillStyle   = 'rgba(80, 220, 100, 0.30)';
+        } else {
+            ctx.strokeStyle = 'rgba(255, 140, 0, 0.95)';
+            ctx.fillStyle   = 'rgba(255, 140, 0, 0.18)';
+        }
+        ctx.fillRect(Math.round(sp.x), Math.round(sp.y), Math.round(ih.w * zoom), Math.round(ih.h * zoom));
+        ctx.strokeRect(Math.round(sp.x), Math.round(sp.y), Math.round(ih.w * zoom), Math.round(ih.h * zoom));
+        ctx.restore();
     }
 
     /** True se a hitbox de interação intersecta o slot {x,y,w,h} dado. */
@@ -1291,36 +1597,8 @@ export class AnimalEntity {
             return;
         }
 
-        // ─── Drinking states (prioridade média, abaixo de FLEE/FOLLOW) ────
-        if (this.state === AnimalState.SEEKING_WATER) {
-            this._updateSeekingWater(now);
-            return;
-        }
-        if (this.state === AnimalState.DRINKING) {
-            this._updateDrinking(now);
-            return;
-        }
-        // Transição: thirst caiu abaixo do threshold → tenta ir beber.
-        // Só dispara se NÃO está em FLEE/FOLLOW (já tratados acima) e o
-        // animal não está machucado/dormindo.
-        if (this._tryEnterSeekingWater()) {
-            this._updateSeekingWater(now);
-            return;
-        }
-
-        // ─── Eating states (Issue #171) — same priority tier as drinking ─
-        if (this.state === AnimalState.SEEKING_FOOD) {
-            this._updateSeekingFood(now);
-            return;
-        }
-        if (this.state === AnimalState.EATING) {
-            this._updateEating(now);
-            return;
-        }
-        if (this._tryEnterSeekingFood()) {
-            this._updateSeekingFood(now);
-            return;
-        }
+        // ─── Drinking/eating states (prioridade média, abaixo de FLEE/FOLLOW) ─
+        if (this._updateNeedStates(now)) return;
 
         if (now - this.stateTimer > this.stateDuration) {
             this.pickNewState();
@@ -1332,6 +1610,26 @@ export class AnimalEntity {
         }
 
         this.updateAnimation(now);
+    }
+
+    /**
+     * Dispatches the drinking/eating states. ORDER MATTERS: water dispatch +
+     * its `_tryEnter` transition come before the food ones, so a thirsty animal
+     * can interrupt eating to go drink (water has priority). A literal
+     * state→handler table would lose this interleaving. Returns true if it
+     * handled the tick (caller should `return`).
+     */
+    _updateNeedStates(now) {
+        if (this.state === AnimalState.SEEKING_WATER) { this._updateSeekingWater(now); return true; }
+        if (this.state === AnimalState.DRINKING) { this._updateDrinking(now); return true; }
+        // Transição: thirst < threshold → tenta ir beber (interrompe comer).
+        if (this._tryEnterSeekingWater()) { this._updateSeekingWater(now); return true; }
+
+        if (this.state === AnimalState.SEEKING_FOOD) { this._updateSeekingFood(now); return true; }
+        if (this.state === AnimalState.EATING) { this._updateEating(now); return true; }
+        if (this._tryEnterSeekingFood()) { this._updateSeekingFood(now); return true; }
+
+        return false;
     }
 
     /**
@@ -1619,6 +1917,12 @@ export class AnimalEntity {
                 const gain = result.fromPremium ? restore.premium : restore.basic;
                 this.stats.hunger = Math.min(100, (this.stats.hunger || 0) + gain);
             } else {
+                // Trough emptied mid-meal. Set the same 5s cooldown the
+                // seek-timeout path uses (line ~1592) so the animal doesn't
+                // immediately re-seek. Without this, not busy-looping relied on
+                // findFreeSlotFor() filtering out empty troughs — decouple from
+                // that filtering so it stays correct if findFreeSlotFor changes.
+                this._eatCooldownUntil = now + 5000;
                 this._exitFoodFlow();
                 return;
             }
@@ -2124,289 +2428,38 @@ export class AnimalEntity {
         // 5+ vezes por animal por frame → 150 syscalls/frame com 30 animais.
         const _now = (frameNow != null) ? frameNow : performance.now();
 
-        const sx = this.frameIndex * this.frameWidth;
-        const sy = this.direction * this.frameHeight;
-        const drawX = Math.floor(screenPos.x);
-        const drawY = Math.floor(screenPos.y);
+        // Camadas, de baixo pra cima (ordem importa). Cada helper é no-op
+        // quando não se aplica (mood CALM, sem produto, sem FX, etc.).
+        this._drawSprite(ctx, screenPos, zoomedWidth, zoomedHeight);
+        this._drawMoodEmoji(ctx, camera, screenPos, zoomedWidth);
+        this._drawPendingProduct(ctx, camera, screenPos, zoomedWidth, _now);
+        this._drawAgeUpFx(ctx, camera, screenPos, zoomedWidth, zoomedHeight, _now);
+        this._drawHitboxDebug(ctx, camera);
 
-        if (this.flipX) {
-            ctx.save();
-            // Translada pro canto direito e inverte X — o sprite desenhado
-            // em (0,0) cai exatamente no lugar de antes, só espelhado.
-            ctx.translate(drawX + zoomedWidth, drawY);
-            ctx.scale(-1, 1);
-            ctx.drawImage(
-                this.img,
-                sx, sy, this.frameWidth, this.frameHeight,
-                0, 0, zoomedWidth, zoomedHeight
-            );
-            ctx.restore();
-        } else {
-            ctx.drawImage(
-                this.img,
-                sx, sy, this.frameWidth, this.frameHeight,
-                drawX, drawY, zoomedWidth, zoomedHeight
-            );
+        // ─── Emote de necessidade (💧 sede / 🍽️ fome) antes de consumir ──
+        // Feedback acima do animal quando precisa mas ainda não está
+        // bebendo/comendo (a barra cobre esses estados). Sede tem prioridade
+        // (mesma ordem do update); um animal não mostra os dois ao mesmo tempo.
+        if ((this.stats.thirst || 0) < this._drinkThreshold && this.state !== AnimalState.DRINKING) {
+            this._drawNeedEmote(ctx, camera, screenPos, zoomedWidth, _now,
+                '💧', this.state === AnimalState.SEEKING_WATER);
+        } else if ((this.stats.hunger || 0) < this._eatThreshold && this.state !== AnimalState.EATING) {
+            this._drawNeedEmote(ctx, camera, screenPos, zoomedWidth, _now,
+                '🍽️', this.state === AnimalState.SEEKING_FOOD);
         }
 
-        if (this._mood !== AnimalMood.CALM) {
-            const emoji = this.moodEmoji;
-            if (emoji) {
-                ctx.save();
-                ctx.font = `${Math.round(14 * camera.zoom)}px sans-serif`;
-                ctx.textAlign = 'center';
-                ctx.fillText(emoji, Math.floor(screenPos.x + zoomedWidth / 2), Math.floor(screenPos.y - 4 * camera.zoom));
-                ctx.restore();
-            }
-        }
-
-        // Indicador de produto pronto pra coleta (🥛 leite, 🧶 lã, 🥚 ovo).
-        // Desenhado um pouco acima do mood emoji, com leve bounce vertical
-        // pra chamar atenção sem ser piscante demais. Visível em qualquer
-        // mood (até SLEEPING — animal pode ter ovo pronto e estar dormindo,
-        // coleta de manhã).
-        if (this._pendingProduct) {
-            const productEmoji = PRODUCT_EMOJI[this._pendingProduct] || '✨';
-            const bounce = Math.sin(_now / 250) * 2 * camera.zoom;
-            ctx.save();
-            ctx.font = `${Math.round(16 * camera.zoom)}px sans-serif`;
-            ctx.textAlign = 'center';
-            ctx.fillText(
-                productEmoji,
-                Math.floor(screenPos.x + zoomedWidth / 2),
-                Math.floor(screenPos.y - 20 * camera.zoom + bounce)
-            );
-            ctx.restore();
-        }
-
-        // FX de aging: sparkles ao redor + texto "Cresceu!" pulsando.
-        // Dura ~2.5s (mais que coleta porque é evento memorável).
-        if (this._ageUpFx) {
-            const fx = this._ageUpFx;
-            const elapsed = _now - fx.startedAt;
-            const duration = fx.duration || 2500;
-            if (elapsed >= duration) {
-                this._ageUpFx = null;
-            } else {
-                const t = elapsed / duration;
-                const alpha = 1 - Math.pow(t, 2);  // fade out quadrático
-                const pulse = 1 + 0.15 * Math.sin(elapsed / 100);
-                ctx.save();
-                ctx.globalAlpha = alpha;
-
-                // Texto "Cresceu!" pulsando acima
-                ctx.font = `bold ${Math.round(13 * camera.zoom * pulse)}px sans-serif`;
-                ctx.textAlign = 'center';
-                ctx.lineWidth = 3 * camera.zoom;
-                ctx.strokeStyle = '#fff';
-                ctx.fillStyle = '#d4a017';
-                const tx = Math.floor(screenPos.x + zoomedWidth / 2);
-                const ty = Math.floor(screenPos.y - 32 * camera.zoom - t * 12 * camera.zoom);
-                ctx.strokeText(fx.text || '✨', tx, ty);
-                ctx.fillText(fx.text || '✨', tx, ty);
-
-                // 4 sparkles orbitando o sprite (rotação simples)
-                ctx.font = `${Math.round(14 * camera.zoom)}px sans-serif`;
-                const cx = screenPos.x + zoomedWidth / 2;
-                const cy = screenPos.y + zoomedHeight / 2;
-                const radius = (zoomedWidth + zoomedHeight) / 2 * (0.6 + t * 0.3);
-                const angleBase = elapsed / 200;
-                for (let i = 0; i < 4; i++) {
-                    const ang = angleBase + i * Math.PI / 2;
-                    const sx2 = cx + Math.cos(ang) * radius;
-                    const sy2 = cy + Math.sin(ang) * radius;
-                    ctx.fillText('✨', Math.floor(sx2), Math.floor(sy2));
-                }
-                ctx.restore();
-            }
-        }
-
-        // Hitbox de interação (laranja/verde). Visível com `?hitboxes=1` na URL.
-        // Verde = atualmente intersecta algo interagível (slot do cocho, etc.)
-        if (getDebugFlag('hitboxes')) {
-            const ih = this.getInteractionHitbox();
-            const sp = camera.worldToScreen(ih.x, ih.y);
-            const zoom = camera.zoom || 1;
-            ctx.save();
-            ctx.lineWidth = 2;
-            if (this._interactionActive) {
-                ctx.strokeStyle = 'rgba(80, 220, 100, 0.95)';
-                ctx.fillStyle   = 'rgba(80, 220, 100, 0.30)';
-            } else {
-                ctx.strokeStyle = 'rgba(255, 140, 0, 0.95)';
-                ctx.fillStyle   = 'rgba(255, 140, 0, 0.18)';
-            }
-            ctx.fillRect(Math.round(sp.x), Math.round(sp.y), Math.round(ih.w * zoom), Math.round(ih.h * zoom));
-            ctx.strokeRect(Math.round(sp.x), Math.round(sp.y), Math.round(ih.w * zoom), Math.round(ih.h * zoom));
-            ctx.restore();
-        }
-
-        // ─── Emote 💧 quando com sede (mas não bebendo ainda) ────────────
-        // Aparece acima do animal quando thirst está abaixo do threshold,
-        // dando feedback ao player sem abrir painel. Esconde durante
-        // DRINKING (a barra já comunica). Bobbing leve pra chamar atenção.
-        const isThirsty = (this.stats.thirst || 0) < this._drinkThreshold;
-        const showThirstEmote = isThirsty && this.state !== AnimalState.DRINKING;
-        if (showThirstEmote) {
-            const now = _now;
-            const bob = Math.sin(now / 280) * 2.5 * camera.zoom;
-            const isSeeking = this.state === AnimalState.SEEKING_WATER;
-            ctx.save();
-            ctx.font = `${Math.round(15 * camera.zoom)}px sans-serif`;
-            ctx.textAlign = 'center';
-            // Sombra discreta pro emote destacar de qualquer fundo.
-            ctx.shadowColor = 'rgba(0, 0, 0, 0.65)';
-            ctx.shadowBlur = 4 * camera.zoom;
-            // Pulsa quando seeking (animal já está atrás de água — feedback "indo!"),
-            // mais quieto quando só está com sede sem agir.
-            ctx.globalAlpha = isSeeking ? (0.65 + 0.35 * Math.abs(Math.sin(now / 220))) : 0.85;
-            ctx.fillText(
-                '💧',
-                Math.floor(screenPos.x + zoomedWidth / 2),
-                Math.floor(screenPos.y - 30 * camera.zoom + bob)
-            );
-            ctx.restore();
-        }
-
-        // ─── Barra de sede + FX visual durante DRINKING ────────────────
+        // ─── Barra de sede (DRINKING) / fome (EATING) ──────────────────
+        // Mesma barra, paletas diferentes. Ver _drawNeedBar + NEED_BAR_*.
         if (this.state === AnimalState.DRINKING) {
-            const now = _now;
-            const barW = Math.max(36, this.width * 0.75) * camera.zoom;
-            const barH = 6 * camera.zoom;
-            const radius = barH / 2;
-            const bx = Math.floor(screenPos.x + (zoomedWidth - barW) / 2);
-            const by = Math.floor(screenPos.y - 14 * camera.zoom);
-            const pct = Math.max(0, Math.min(1, (this.stats.thirst || 0) / 100));
-
-            // Quality mode: low = só barra básica (fill simples + outline).
-            // Medium/high = todos os FX (halo, gradient, shine, bolhas, shadow).
-            const heavyFX = qualityMode.enableHeavyFX;
-
-            ctx.save();
-
-            // Halo radial sob o animal (HEAVY — radialGradient é caro).
-            if (heavyFX) {
-                const haloX = screenPos.x + zoomedWidth / 2;
-                const haloY = screenPos.y + zoomedHeight - 4 * camera.zoom;
-                const haloR = Math.max(zoomedWidth, zoomedHeight) * 0.45;
-                const halo = ctx.createRadialGradient(haloX, haloY, 0, haloX, haloY, haloR);
-                halo.addColorStop(0, 'rgba(120, 200, 255, 0.22)');
-                halo.addColorStop(1, 'rgba(120, 200, 255, 0)');
-                ctx.fillStyle = halo;
-                ctx.beginPath();
-                ctx.arc(haloX, haloY, haloR, 0, Math.PI * 2);
-                ctx.fill();
-            }
-
-            // Ícone 💧 antes da barra (sempre — é só um texto).
-            const iconBounce = heavyFX ? Math.sin(now / 200) * 1.5 * camera.zoom : 0;
-            ctx.font = `${Math.round(11 * camera.zoom)}px sans-serif`;
-            ctx.textAlign = 'right';
-            ctx.textBaseline = 'middle';
-            if (heavyFX) {
-                ctx.shadowColor = 'rgba(0, 0, 0, 0.55)';
-                ctx.shadowBlur = 3 * camera.zoom;
-            }
-            ctx.fillStyle = '#cde9ff';
-            ctx.fillText('💧', bx - 3 * camera.zoom, by + barH / 2 + iconBounce);
-            ctx.shadowBlur = 0;
-
-            // Fundo da barra — gradient no high, cor sólida no low.
-            if (heavyFX) {
-                const bgGrad = ctx.createLinearGradient(bx, by, bx, by + barH);
-                bgGrad.addColorStop(0, 'rgba(8, 20, 38, 0.85)');
-                bgGrad.addColorStop(1, 'rgba(4, 12, 24, 0.85)');
-                ctx.fillStyle = bgGrad;
-            } else {
-                ctx.fillStyle = 'rgba(6, 16, 30, 0.85)';
-            }
-            this._roundRect(ctx, bx, by, barW, barH, radius);
-            ctx.fill();
-
-            // Preenchimento — gradient + shadow + shine no high, fill simples no low.
-            const fillW = Math.max(0, Math.round(barW * pct));
-            if (fillW > 1) {
-                if (heavyFX) {
-                    const pulse = 0.85 + 0.15 * Math.sin(now / 180);
-                    const fillGrad = ctx.createLinearGradient(bx, by, bx, by + barH);
-                    fillGrad.addColorStop(0, '#9be3ff');
-                    fillGrad.addColorStop(0.5, '#5bbcff');
-                    fillGrad.addColorStop(1, '#2d7ec8');
-                    ctx.fillStyle = fillGrad;
-                    ctx.shadowColor = `rgba(123, 200, 255, ${0.55 * pulse})`;
-                    ctx.shadowBlur = 8 * camera.zoom;
-                    this._roundRect(ctx, bx, by, fillW, barH, radius);
-                    ctx.fill();
-                    ctx.shadowBlur = 0;
-
-                    // Shine animado atravessando a barra.
-                    const shineX = bx + ((now / 12) % (barW + 20)) - 10;
-                    if (shineX > bx && shineX < bx + fillW - 4) {
-                        const shineGrad = ctx.createLinearGradient(shineX - 6, 0, shineX + 6, 0);
-                        shineGrad.addColorStop(0, 'rgba(255, 255, 255, 0)');
-                        shineGrad.addColorStop(0.5, 'rgba(255, 255, 255, 0.55)');
-                        shineGrad.addColorStop(1, 'rgba(255, 255, 255, 0)');
-                        ctx.fillStyle = shineGrad;
-                        ctx.fillRect(shineX - 6, by + 1, 12, barH - 2);
-                    }
-                } else {
-                    // Low: fill chapado cyan.
-                    ctx.fillStyle = '#5bbcff';
-                    this._roundRect(ctx, bx, by, fillW, barH, radius);
-                    ctx.fill();
-                }
-            }
-
-            // Contorno (sempre — barato).
-            ctx.strokeStyle = heavyFX ? 'rgba(255, 230, 180, 0.7)' : 'rgba(255, 230, 180, 0.4)';
-            ctx.lineWidth = Math.max(1, camera.zoom);
-            this._roundRect(ctx, bx, by, barW, barH, radius);
-            ctx.stroke();
-
-            // Bolhas subindo (HEAVY — 3 arcs por frame).
-            if (heavyFX && fillW > 6) {
-                ctx.fillStyle = 'rgba(255, 255, 255, 0.55)';
-                for (let i = 0; i < 3; i++) {
-                    const phase = (now / 600 + i * 0.33) % 1;
-                    const bbX = bx + 4 * camera.zoom + (i * (fillW - 10) / 3);
-                    const bbY = by + barH - phase * (barH - 2);
-                    if (bbX < bx + fillW - 2) {
-                        ctx.beginPath();
-                        ctx.arc(bbX, bbY, 1 * camera.zoom, 0, Math.PI * 2);
-                        ctx.fill();
-                    }
-                }
-            }
-
-            ctx.restore();
+            this._drawNeedBar(ctx, camera, screenPos, zoomedWidth, zoomedHeight,
+                _now, NEED_BAR_THIRST, (this.stats.thirst || 0) / 100);
+        } else if (this.state === AnimalState.EATING) {
+            this._drawNeedBar(ctx, camera, screenPos, zoomedWidth, zoomedHeight,
+                _now, NEED_BAR_HUNGER, (this.stats.hunger || 0) / 100);
         }
 
-        // FX flutuante de coleta (sucesso/falha). Texto sobe e desaparece
-        // em ~1.5s. Stroke branco pra legibilidade sobre qualquer fundo.
-        if (this._collectFx) {
-            const fx = this._collectFx;
-            const elapsed = _now - fx.startedAt;
-            const duration = fx.duration || 1500;
-            if (elapsed >= duration) {
-                this._collectFx = null;
-            } else {
-                const t = elapsed / duration;
-                const alpha = 1 - t;
-                const yOffset = -34 - (t * 18);  // sobe 18px no fim
-                ctx.save();
-                ctx.globalAlpha = alpha;
-                ctx.font = `bold ${Math.round(12 * camera.zoom)}px sans-serif`;
-                ctx.textAlign = 'center';
-                ctx.lineWidth = 3 * camera.zoom;
-                ctx.strokeStyle = '#fff';
-                ctx.fillStyle = fx.success ? '#1f8b3a' : '#b73030';
-                const tx = Math.floor(screenPos.x + zoomedWidth / 2);
-                const ty = Math.floor(screenPos.y + yOffset * camera.zoom);
-                ctx.strokeText(fx.text, tx, ty);
-                ctx.fillText(fx.text, tx, ty);
-                ctx.restore();
-            }
-        }
+        // FX flutuante de coleta (sucesso/falha).
+        this._drawCollectFx(ctx, camera, screenPos, zoomedWidth, _now);
     }
 
     serialize() {

--- a/public/scripts/animal/troughSlots.js
+++ b/public/scripts/animal/troughSlots.js
@@ -1,0 +1,123 @@
+/**
+ * @file troughSlots.js - Shared slot machinery for food & water troughs.
+ * @description Both troughs expose 3 slots so multiple animals can feed/drink
+ * side by side without overlapping. The occupancy bookkeeping, the slot→world
+ * rect mapping, and the "where does the animal stand" geometry were duplicated
+ * almost verbatim between foodTroughSystem.js and waterTroughSystem.js. This
+ * module is the single source of truth.
+ *
+ * IMPORTANT: food and water keep SEPARATE occupancy — each system creates its
+ * own `createSlotRegistry()` instance (its own Map). They must never share one.
+ * @module TroughSlots
+ */
+
+export const TROUGH_SLOT_COUNT = 3;
+
+/**
+ * Creates an isolated slot-occupancy registry: a `troughId -> [animalId|null]`
+ * map plus claim/release helpers. One instance per trough system.
+ * @param {number} [slotCount=TROUGH_SLOT_COUNT]
+ */
+export function createSlotRegistry(slotCount = TROUGH_SLOT_COUNT) {
+    const occupancy = new Map(); // troughId -> Array<animalId|null> (length slotCount)
+
+    function occupancyFor(troughId) {
+        let arr = occupancy.get(troughId);
+        if (!arr) {
+            arr = new Array(slotCount).fill(null);
+            occupancy.set(troughId, arr);
+        }
+        return arr;
+    }
+
+    return {
+        /** Raw map — read-only iteration (e.g. debug overlays counting occupied slots). */
+        occupancy,
+        occupancyFor,
+
+        /**
+         * Reserve a slot for the animal. Idempotent (re-claim by same animal =
+         * ok). Fails (false) if another animal owns it.
+         */
+        claimSlot(troughId, slotIdx, animalId) {
+            if (slotIdx < 0 || slotIdx >= slotCount) return false;
+            const occ = occupancyFor(troughId);
+            if (occ[slotIdx] != null && occ[slotIdx] !== animalId) return false;
+            occ[slotIdx] = animalId;
+            return true;
+        },
+
+        /** Release the slot only if `animalId` owns it (safe otherwise). */
+        releaseSlot(troughId, slotIdx, animalId) {
+            if (slotIdx < 0 || slotIdx >= slotCount) return;
+            const occ = occupancy.get(troughId);
+            if (!occ) return;
+            if (occ[slotIdx] === animalId) occ[slotIdx] = null;
+        },
+
+        /** Free every slot held by this animal (cleanup on death / state escape). */
+        releaseAllSlotsFor(animalId) {
+            for (const [, occ] of occupancy) {
+                for (let i = 0; i < occ.length; i++) {
+                    if (occ[i] === animalId) occ[i] = null;
+                }
+            }
+        },
+    };
+}
+
+/**
+ * Maps slot config ratios to world-space rects on a given trough.
+ * Each slot config is `{ offsetX, offsetY, w, h }` (fractions of trough size).
+ * @returns {Array<{idx:number,x:number,y:number,w:number,h:number}>}
+ */
+export function slotWorldRects(trough, slotConfigs) {
+    if (!trough || !Array.isArray(slotConfigs)) return [];
+    return slotConfigs.map((s, idx) => ({
+        idx,
+        x: trough.x + trough.width * s.offsetX,
+        y: trough.y + trough.height * s.offsetY,
+        w: trough.width * s.w,
+        h: trough.height * s.h,
+    }));
+}
+
+/**
+ * Where the animal must stand to use a slot: its collision box flush against
+ * the OUTSIDE trough edge nearest the slot, perpendicular to the long axis,
+ * aligned with the slot center. Uses the collision box (real body) not the
+ * sprite, so big sprites with small bodies (Bull) still touch the trough.
+ * @param {boolean} isHorizontal - trough laid out along X (slots side by side).
+ * @param {number} [gap=2] - px gap between body and trough edge.
+ * @returns {{x:number,y:number,facing:string}}
+ */
+export function troughStandPosition(trough, slot, animal, isHorizontal, gap = 2) {
+    const slotCx = slot.x + slot.w / 2;
+    const slotCy = slot.y + slot.h / 2;
+
+    const cb = animal?.collisionBox
+        || { offsetX: 0, offsetY: 0, width: animal?.width || 32, height: animal?.height || 32 };
+    const cbX = cb.offsetX || 0;
+    const cbY = cb.offsetY || 0;
+    const cbW = cb.width  || animal?.width  || 32;
+    const cbH = cb.height || animal?.height || 32;
+
+    if (isHorizontal) {
+        const fromAbove = (animal?.y ?? 0) < slotCy;
+        return {
+            x: slotCx - cbX - cbW / 2,
+            y: fromAbove
+                ? (trough.y - gap - cbY - cbH)
+                : (trough.y + trough.height + gap - cbY),
+            facing: fromAbove ? 'down' : 'up',
+        };
+    }
+    const fromLeft = (animal?.x ?? 0) < slotCx;
+    return {
+        x: fromLeft
+            ? (trough.x - gap - cbX - cbW)
+            : (trough.x + trough.width + gap - cbX),
+        y: slotCy - cbY - cbH / 2,
+        facing: fromLeft ? 'right' : 'left',
+    };
+}

--- a/public/scripts/foodTroughSystem.js
+++ b/public/scripts/foodTroughSystem.js
@@ -19,6 +19,7 @@ import { handleWarn } from "./errorHandler.js";
 import { logger } from "./logger.js";
 import { t } from "./i18n/i18n.js";
 import { getItem } from "./itemUtils.js";
+import { createSlotRegistry, slotWorldRects, troughStandPosition } from "./animal/troughSlots.js";
 
 const FOOD_TROUGH_CONFIG = {
   MAX_FOOD_LEVEL: 100,
@@ -27,7 +28,9 @@ const FOOD_TROUGH_CONFIG = {
   PREMIUM_PER_FEED: 50,
 };
 
-// Map animal asset name → species code (cattle/pork/bird)
+// Map animal asset name → species code. There are only three trough species
+// (cattle/pork/bird); Sheep/Lamb intentionally share the cattle trough — they're
+// grazing livestock and there's no dedicated sheep trough variant. (#179)
 const ANIMAL_TO_SPECIES = {
   Cow: "cattle", Bull: "cattle", Calf: "cattle",
   Sheep: "cattle", Lamb: "cattle",
@@ -83,17 +86,9 @@ function _slotsFor(variant) {
   return (variant || '').endsWith('Y') ? _SLOTS_Y : _SLOTS_X;
 }
 
-// Slot reservation map: troughId → [animalId|null, ...] (3 slots).
-const _slotOccupancy = new Map();
-
-function _occupancyFor(troughId) {
-  let arr = _slotOccupancy.get(troughId);
-  if (!arr) {
-    arr = [null, null, null];
-    _slotOccupancy.set(troughId, arr);
-  }
-  return arr;
-}
+// Slot reservation: troughId → [animalId|null, ...] (3 slots). Own registry
+// instance — food occupancy is separate from water's. See troughSlots.js.
+const _slots = createSlotRegistry();
 
 let _hoveredId = null;
 let _ftToastEl = null;
@@ -165,7 +160,7 @@ function _findFeedInInventory(trough, premium) {
   const inv = inventorySystem.getInventory?.();
   const slots = inv?.animal_food?.items || [];
   for (const slot of slots) {
-    if ((slot.quantity || slot.qty || 0) <= 0) continue;
+    if ((slot.quantity || 0) <= 0) continue;
     const itemData = getItem(slot.id);
     if (!itemData) continue;
     if (premium) {
@@ -400,19 +395,12 @@ export const foodTroughSystem = {
   getEatSlots(troughOrId) {
     const ft = (typeof troughOrId === 'string') ? _findTrough(troughOrId) : troughOrId;
     if (!ft) return [];
-    const slots = _slotsFor(ft.variant);
-    return slots.map((s, idx) => ({
-      idx,
-      x: ft.x + ft.width * s.offsetX,
-      y: ft.y + ft.height * s.offsetY,
-      w: ft.width * s.w,
-      h: ft.height * s.h,
-    }));
+    return slotWorldRects(ft, _slotsFor(ft.variant));
   },
 
   // Find the index of a free slot in this trough, or -1.
   findFreeSlotIn(troughId, animalId) {
-    const occ = _occupancyFor(troughId);
+    const occ = _slots.occupancyFor(troughId);
     for (let i = 0; i < occ.length; i++) {
       if (occ[i] == null || occ[i] === animalId) return i;
       // Stale check: slot owner no longer exists in world.
@@ -485,61 +473,18 @@ export const foodTroughSystem = {
    */
   getEatPosition(trough, slot, animal) {
     const isHorizontal = !(trough.variant || '').endsWith('Y');
-    const GAP = 2;
-    const slotCx = slot.x + slot.w / 2;
-    const slotCy = slot.y + slot.h / 2;
-
-    const cb = animal?.collisionBox
-      || { offsetX: 0, offsetY: 0, width: animal?.width || 32, height: animal?.height || 32 };
-    const cbX = cb.offsetX || 0;
-    const cbY = cb.offsetY || 0;
-    const cbW = cb.width  || animal?.width  || 32;
-    const cbH = cb.height || animal?.height || 32;
-
-    if (isHorizontal) {
-      const fromAbove = (animal?.y ?? 0) < slotCy;
-      return {
-        x: slotCx - cbX - cbW / 2,
-        y: fromAbove
-            ? (trough.y - GAP - cbY - cbH)
-            : (trough.y + trough.height + GAP - cbY),
-        facing: fromAbove ? 'down' : 'up',
-      };
-    }
-    const fromLeft = (animal?.x ?? 0) < slotCx;
-    return {
-      x: fromLeft
-          ? (trough.x - GAP - cbX - cbW)
-          : (trough.x + trough.width + GAP - cbX),
-      y: slotCy - cbY - cbH / 2,
-      facing: fromLeft ? 'right' : 'left',
-    };
+    return troughStandPosition(trough, slot, animal, isHorizontal);
   },
 
-  // Reserve a slot for the animal. Idempotent (re-claim by same animal = ok).
+  // Slot reservation — delegated to the shared registry (see troughSlots.js).
   claimSlot(troughId, slotIdx, animalId) {
-    if (slotIdx < 0 || slotIdx > 2) return false;
-    const occ = _occupancyFor(troughId);
-    if (occ[slotIdx] != null && occ[slotIdx] !== animalId) return false;
-    occ[slotIdx] = animalId;
-    return true;
+    return _slots.claimSlot(troughId, slotIdx, animalId);
   },
-
-  // Release the slot if the animal owns it. Safe if owned by someone else.
   releaseSlot(troughId, slotIdx, animalId) {
-    if (slotIdx < 0 || slotIdx > 2) return;
-    const occ = _slotOccupancy.get(troughId);
-    if (!occ) return;
-    if (occ[slotIdx] === animalId) occ[slotIdx] = null;
+    _slots.releaseSlot(troughId, slotIdx, animalId);
   },
-
-  // Free every slot held by this animal (cleanup on death / state escape).
   releaseAllSlotsFor(animalId) {
-    for (const [, occ] of _slotOccupancy) {
-      for (let i = 0; i < occ.length; i++) {
-        if (occ[i] === animalId) occ[i] = null;
-      }
-    }
+    _slots.releaseAllSlotsFor(animalId);
   },
 
   /**
@@ -557,10 +502,24 @@ export const foodTroughSystem = {
       ? animal.getInteractionHitbox()
       : null;
     if (!ih) return false;
-    return ih.x < slot.x + slot.w &&
-           ih.x + ih.w > slot.x &&
-           ih.y < slot.y + slot.h &&
-           ih.y + ih.h > slot.y;
+
+    const overlaps = (r) =>
+      ih.x < r.x + (r.w ?? r.width) &&
+      ih.x + ih.w > r.x &&
+      ih.y < r.y + (r.h ?? r.height) &&
+      ih.y + ih.h > r.y;
+
+    // Primary: reach hitbox pokes into the claimed slot.
+    if (overlaps(slot)) return true;
+
+    // Fallback (mirrors the water trough's lenient body-in-bounds check):
+    // small species (Chicken/Chick) have a short reach hitbox that pokes into
+    // the trough but falls short of the inset slot rect, so the strict slot
+    // overlap above never matched and they bounced out of EATING immediately
+    // (#179). The animal is positioned at the trough edge by getEatPosition,
+    // so a reach touching the trough's outer bounds means it's in place to eat.
+    const trough = _findTrough(troughId);
+    return !!trough && overlaps(trough);
   },
 
   // Back-compat: any slot of the trough.
@@ -589,7 +548,7 @@ export const foodTroughSystem = {
 
     for (const ft of this.getFoodTroughs()) {
       const slots = this.getEatSlots(ft);
-      const occ = _slotOccupancy.get(ft.id) || [];
+      const occ = _slots.occupancy.get(ft.id) || [];
       for (const s of slots) {
         const screen = camera.worldToScreen(s.x, s.y);
         const sx = Math.round(screen.x);

--- a/public/scripts/thePlayer/inventoryUI.js
+++ b/public/scripts/thePlayer/inventoryUI.js
@@ -1011,7 +1011,7 @@ function renderInventory() {
     const fullItem = getItem(slot.id);
     if (!fullItem) return;
 
-    const itemQuantity = slot.quantity || slot.qty || 1;
+    const itemQuantity = slot.quantity || 1;
     const isEquipped = equippedId === slot.id;
     const slotEl = document.createElement('div');
     slotEl.className = `inv-slot ${selectedSlotIndex === index ? 'selected' : ''}${isEquipped ? ' inv-slot-equipped' : ''}`;

--- a/public/scripts/thePlayer/toolWheel.js
+++ b/public/scripts/thePlayer/toolWheel.js
@@ -81,7 +81,7 @@ function _refreshEntries() {
   for (const slot of toolSlots) {
     const item = getItem(slot.id);
     if (!item || item.type !== 'tool') continue;
-    tools.push({ id: slot.id, item, quantity: slot.quantity || slot.qty || 1 });
+    tools.push({ id: slot.id, item, quantity: slot.quantity || 1 });
   }
 
   // Primeiro slot sempre é "desequipar"

--- a/public/scripts/waterTroughSystem.js
+++ b/public/scripts/waterTroughSystem.js
@@ -16,6 +16,7 @@ import { registerSystem, getSystem, getDebugFlag } from "./gameState.js";
 import { handleWarn } from "./errorHandler.js";
 import { logger } from "./logger.js";
 import { t } from "./i18n/i18n.js";
+import { createSlotRegistry, slotWorldRects, troughStandPosition } from "./animal/troughSlots.js";
 
 const WATER_TROUGH_CONFIG = {
   ITEM_ID_IN_HAND: 103,
@@ -65,18 +66,9 @@ const DRINK_SLOTS = {
 // Estado de hover atualizado pelo mousemove em control.js.
 let _hoveredId = null;
 
-// Ocupação de slots: Map<troughId, Array<animalId|null>> com 3 entradas.
-// Garante que no máximo 3 animais bebem por cocho, 1 por compartimento.
-const _slotOccupancy = new Map();
-
-function _occupancyFor(troughId) {
-  let arr = _slotOccupancy.get(troughId);
-  if (!arr) {
-    arr = [null, null, null];
-    _slotOccupancy.set(troughId, arr);
-  }
-  return arr;
-}
+// Ocupação de slots (Map<troughId, [animalId|null × 3]>). Registry próprio —
+// água é separada da comida. Garante no máx. 3 animais por cocho. troughSlots.js.
+const _slots = createSlotRegistry();
 
 function findTrough(id) {
   if (!id || !Array.isArray(placedBuildings)) return null;
@@ -363,12 +355,12 @@ export const waterTroughSystem = {
 
   /**
    * Procura um slot livre num cocho específico. Retorna o índice (0..2)
-   * ou -1 se todos ocupados. "Livre" = entrada do _slotOccupancy é null,
+   * ou -1 se todos ocupados. "Livre" = entrada de ocupação é null,
    * é o próprio animalId, ou cleanup oportunístico detectou um claim órfão
    * (animal sumiu, ou animal abandonou o estado de bebida sem liberar).
    */
   findFreeSlotIn(troughId, animalId) {
-    const occ = _occupancyFor(troughId);
+    const occ = _slots.occupancyFor(troughId);
     for (let i = 0; i < occ.length; i++) {
       if (occ[i] == null || occ[i] === animalId) return i;
       // Stale check (1): dono não existe mais no mundo.
@@ -456,93 +448,29 @@ export const waterTroughSystem = {
    */
   getDrinkPosition(trough, slot, animal) {
     const isHorizontal = (trough.variant || 'waterTroughX') === 'waterTroughX';
-    const GAP = 2;
-    const slotCx = slot.x + slot.w / 2;
-    const slotCy = slot.y + slot.h / 2;
-
-    // Usa COLLISION BOX (corpo real) pra posicionar — não o sprite todo.
-    // Bull tem sprite 48 mas corpo ~14×14 com offsetY ~24. Se usássemos
-    // o sprite, o animal ficaria 12+px longe do cocho (sprite encosta,
-    // corpo fica longe). Com a collision box, o corpo encosta no cocho.
-    const cb = animal?.collisionBox || { offsetX: 0, offsetY: 0, width: animal?.width || 32, height: animal?.height || 32 };
-    const cbX = cb.offsetX || 0;
-    const cbY = cb.offsetY || 0;
-    const cbW = cb.width  || animal?.width  || 32;
-    const cbH = cb.height || animal?.height || 32;
-
-    if (isHorizontal) {
-      const fromAbove = (animal?.y ?? 0) < slotCy;
-      // Animal.x tal que centro da collision box bate no centro do slot.
-      // Animal.y tal que bottom (ou top) da collision box encosta no cocho.
-      return {
-        x: slotCx - cbX - cbW / 2,
-        y: fromAbove
-            ? (trough.y - GAP - cbY - cbH)
-            : (trough.y + trough.height + GAP - cbY),
-        facing: fromAbove ? 'down' : 'up',
-      };
-    }
-    const fromLeft = (animal?.x ?? 0) < slotCx;
-    return {
-      x: fromLeft
-          ? (trough.x - GAP - cbX - cbW)
-          : (trough.x + trough.width + GAP - cbX),
-      y: slotCy - cbY - cbH / 2,
-      facing: fromLeft ? 'right' : 'left',
-    };
+    return troughStandPosition(trough, slot, animal, isHorizontal);
   },
 
-  /**
-   * Reserva o slot pro animal. Retorna true se claim foi bem-sucedido.
-   * Falha se o slot já tem outro dono. Idempotente: re-claim pelo mesmo
-   * animal é no-op com sucesso.
-   */
+  // Slot reservation — delegated to the shared registry (see troughSlots.js).
   claimSlot(troughId, slotIdx, animalId) {
-    if (slotIdx < 0 || slotIdx > 2) return false;
-    const occ = _occupancyFor(troughId);
-    if (occ[slotIdx] != null && occ[slotIdx] !== animalId) return false;
-    occ[slotIdx] = animalId;
-    return true;
+    return _slots.claimSlot(troughId, slotIdx, animalId);
   },
-
-  /**
-   * Libera o slot SE o dono atual for o animal especificado. Caso o
-   * slot já esteja com outro (ex: cleanup orfão), não toca.
-   */
   releaseSlot(troughId, slotIdx, animalId) {
-    if (slotIdx < 0 || slotIdx > 2) return;
-    const occ = _slotOccupancy.get(troughId);
-    if (!occ) return;
-    if (occ[slotIdx] === animalId) occ[slotIdx] = null;
+    _slots.releaseSlot(troughId, slotIdx, animalId);
   },
-
-  /** Libera TODOS os slots ocupados por esse animal. Pra cleanup quando
-   *  animal morre/sai do estado de drinking sem chamar release explícito. */
   releaseAllSlotsFor(animalId) {
-    for (const [, occ] of _slotOccupancy) {
-      for (let i = 0; i < occ.length; i++) {
-        if (occ[i] === animalId) occ[i] = null;
-      }
-    }
+    _slots.releaseAllSlotsFor(animalId);
   },
 
   /**
-   * Retorna os slots de bebida do cocho em coords de mundo (já aplicado
-   * o ratio sobre x/y/width/height do cocho). Cada slot:
-   *   { idx, x, y, w, h }
+   * Retorna os slots de bebida do cocho em coords de mundo (ratio aplicado
+   * sobre x/y/width/height). Cada slot: { idx, x, y, w, h }.
    */
   getDrinkSlots(troughOrId) {
     const wt = (typeof troughOrId === 'string') ? findTrough(troughOrId) : troughOrId;
     if (!wt) return [];
     const variant = wt.variant || 'waterTroughX';
-    const slots = DRINK_SLOTS[variant] || [];
-    return slots.map((s, idx) => ({
-      idx,
-      x: wt.x + wt.width * s.offsetX,
-      y: wt.y + wt.height * s.offsetY,
-      w: wt.width * s.w,
-      h: wt.height * s.h,
-    }));
+    return slotWorldRects(wt, DRINK_SLOTS[variant] || []);
   },
 
   /**
@@ -562,7 +490,7 @@ export const waterTroughSystem = {
 
     for (const wt of this.getWaterTroughs()) {
       const slots = this.getDrinkSlots(wt);
-      const occ = _slotOccupancy.get(wt.id) || [];
+      const occ = _slots.occupancy.get(wt.id) || [];
       for (const s of slots) {
         const screen = camera.worldToScreen(s.x, s.y);
         const sx = Math.round(screen.x);

--- a/tests/unit/troughSlots.test.js
+++ b/tests/unit/troughSlots.test.js
@@ -1,0 +1,117 @@
+import { describe, test, expect } from 'bun:test';
+import {
+    createSlotRegistry,
+    slotWorldRects,
+    troughStandPosition,
+    TROUGH_SLOT_COUNT,
+} from '../../public/scripts/animal/troughSlots.js';
+
+describe('troughSlots — createSlotRegistry', () => {
+    test('claim reserves a slot; re-claim by same animal is idempotent', () => {
+        const r = createSlotRegistry();
+        expect(r.claimSlot('t1', 0, 'a')).toBe(true);
+        expect(r.claimSlot('t1', 0, 'a')).toBe(true); // same animal, ok
+        expect(r.claimSlot('t1', 0, 'b')).toBe(false); // taken by a
+    });
+
+    test('out-of-range slot index is rejected', () => {
+        const r = createSlotRegistry();
+        expect(r.claimSlot('t1', -1, 'a')).toBe(false);
+        expect(r.claimSlot('t1', TROUGH_SLOT_COUNT, 'a')).toBe(false);
+    });
+
+    test('releaseSlot frees only when the animal owns it', () => {
+        const r = createSlotRegistry();
+        r.claimSlot('t1', 1, 'a');
+        r.releaseSlot('t1', 1, 'b'); // not owner — no-op
+        expect(r.claimSlot('t1', 1, 'b')).toBe(false);
+        r.releaseSlot('t1', 1, 'a'); // owner — frees
+        expect(r.claimSlot('t1', 1, 'b')).toBe(true);
+    });
+
+    test('releaseAllSlotsFor frees the animal across every trough', () => {
+        const r = createSlotRegistry();
+        r.claimSlot('t1', 0, 'a');
+        r.claimSlot('t2', 2, 'a');
+        r.claimSlot('t1', 1, 'b');
+        r.releaseAllSlotsFor('a');
+        expect(r.claimSlot('t1', 0, 'x')).toBe(true);
+        expect(r.claimSlot('t2', 2, 'x')).toBe(true);
+        expect(r.claimSlot('t1', 1, 'x')).toBe(false); // b still holds it
+    });
+
+    test('separate registries are isolated (food vs water must not share)', () => {
+        const food = createSlotRegistry();
+        const water = createSlotRegistry();
+        food.claimSlot('shared-id', 0, 'a');
+        // Same trough id, different registry → still free.
+        expect(water.claimSlot('shared-id', 0, 'b')).toBe(true);
+    });
+
+    // Mirrors findFreeSlotIn: grab the first free slot index, or -1.
+    function claimAnyFree(reg, troughId, animalId) {
+        for (let i = 0; i < TROUGH_SLOT_COUNT; i++) {
+            if (reg.claimSlot(troughId, i, animalId)) return i;
+        }
+        return -1;
+    }
+
+    test('6 animals at one trough: 3 eat at once, the rest wait then eat in waves', () => {
+        const r = createSlotRegistry();
+        const trough = 't1';
+        const herd = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+        // First wave: only 3 can claim a slot (1 per compartment).
+        const wave1 = herd.map((id) => claimAnyFree(r, trough, id));
+        expect(wave1.slice(0, 3)).toEqual([0, 1, 2]); // a,b,c get the 3 slots
+        expect(wave1.slice(3)).toEqual([-1, -1, -1]); // d,e,f must wait
+
+        // a & b finish eating and release → 2 slots open up.
+        r.releaseSlot(trough, 0, 'a');
+        r.releaseSlot(trough, 1, 'b');
+
+        // Next wave: 2 waiters claim the freed slots; the last still waits.
+        expect(claimAnyFree(r, trough, 'd')).toBe(0);
+        expect(claimAnyFree(r, trough, 'e')).toBe(1);
+        expect(claimAnyFree(r, trough, 'f')).toBe(-1); // c still holds slot 2
+
+        // c finishes → f finally gets in. All 6 have eaten over the waves.
+        r.releaseSlot(trough, 2, 'c');
+        expect(claimAnyFree(r, trough, 'f')).toBe(2);
+    });
+});
+
+describe('troughSlots — slotWorldRects', () => {
+    test('maps ratio configs to world rects on the trough', () => {
+        const trough = { x: 100, y: 200, width: 64, height: 32 };
+        const cfgs = [{ offsetX: 0.5, offsetY: 0.25, w: 0.5, h: 0.5 }];
+        expect(slotWorldRects(trough, cfgs)).toEqual([
+            { idx: 0, x: 100 + 32, y: 200 + 8, w: 32, h: 16 },
+        ]);
+    });
+
+    test('returns [] for missing trough or configs', () => {
+        expect(slotWorldRects(null, [])).toEqual([]);
+        expect(slotWorldRects({ x: 0, y: 0, width: 1, height: 1 }, null)).toEqual([]);
+    });
+});
+
+describe('troughSlots — troughStandPosition', () => {
+    const trough = { x: 100, y: 200, width: 64, height: 20 };
+    const slot = { x: 116, y: 205, w: 18, h: 10 }; // center (125, 210)
+    const animal = { x: 0, y: 0, collisionBox: { offsetX: 2, offsetY: 6, width: 16, height: 10 } };
+
+    test('horizontal, animal above → stands above with facing down', () => {
+        const pos = troughStandPosition(trough, slot, { ...animal, y: 0 }, true);
+        // x: slotCx - cbX - cbW/2 = 125 - 2 - 8 = 115; y: trough.y - GAP - cbY - cbH = 200-2-6-10 = 182
+        expect(pos).toEqual({ x: 115, y: 182, facing: 'down' });
+    });
+
+    test('vertical, animal left → stands left with facing right', () => {
+        const vTrough = { x: 100, y: 200, width: 20, height: 64 };
+        const vSlot = { x: 105, y: 216, w: 10, h: 18 }; // center (110, 225)
+        const pos = troughStandPosition(vTrough, vSlot, { ...animal, x: 0 }, false);
+        // x: trough.x - GAP - cbX - cbW = 100-2-2-16 = 80; y: slotCy - cbY - cbH/2 = 225-6-5 = 214
+        expect(pos).toEqual({ x: 80, y: 214, facing: 'right' });
+    });
+});


### PR DESCRIPTION
fix #179 

Refactor: Animal Draw Split + Trough Slot Registry + Hunger UX


Animal (animalAI.js)

- Split the ~430-line draw() into focused, allocation-free helpers:
  `_drawNeedBar` unifying thirst/hunger bars via module palettes, plus 
  `_drawNeedEmote/_drawCollectFx/_drawSprite/_drawMoodEmoji/_drawPendingProduct/
  _drawAgeUpFx/_drawHitboxDebug`
- draw() is now a ~50-line layer list
- Add a hunger bar (🌾) during EATING and a hunger emote (🍽️), mirroring thirst
- Extract drink/eat dispatch into `_updateNeedStates()`, preserving the water-before-food order so thirst still interrupts eating

Troughs (animal/troughSlots.js)

- Extract the slot logic duplicated by food/water troughs:
  `createSlotRegistry()` for isolated per-system occupancy
  `slotWorldRects()`, `troughStandPosition()`
- foodTrough `isAnimalAtSlot` falls back to lenient trough-bounds so small species (Chicken/Chick) can eat

Tests

Add `troughSlots.test.js` (10) incl. the 3-slots/6-animals wave case.

Notes

Behavior-preserving except the intentional hunger bar/emote additions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Animals now display animated need bars and emotes to visually indicate thirst and hunger.

* **Improvements**
  * Enhanced animal behavior: thirsty animals can now pause eating to prioritize drinking.
  * Fixed inventory quantity display across the UI and tool selection systems.

* **Tests**
  * Added comprehensive unit tests for trough slot management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->